### PR TITLE
#9: init eslint template exempts test files from size rules

### DIFF
--- a/src/cli/init/scaffold-eslint-config.test.ts
+++ b/src/cli/init/scaffold-eslint-config.test.ts
@@ -38,6 +38,14 @@ describe('scaffoldEslintConfig', () => {
     expect(contents).toContain('max: 200');
   });
 
+  it('exempts test files from the size rules, matching TEST_FILE_EXCLUDE', () => {
+    scaffoldEslintConfig(cwd);
+    const contents = readFileSync(join(cwd, 'eslint.config.js'), 'utf8');
+    expect(contents).toContain("files: ['**/*.test.ts', '**/*.spec.ts', 'tests/**']");
+    expect(contents).toContain("'max-lines-per-function': 'off'");
+    expect(contents).toContain("'max-lines': 'off'");
+  });
+
   it('does not overwrite an existing eslint.config.mjs', () => {
     const path = join(cwd, 'eslint.config.mjs');
     writeFileSync(path, 'export default [];\n');

--- a/src/cli/init/templates/eslint-config.ts
+++ b/src/cli/init/templates/eslint-config.ts
@@ -31,5 +31,12 @@ export default tseslint.config(
       '@typescript-eslint/no-inferrable-types': 'error',
     },
   },
+  {
+    files: ['**/*.test.ts', '**/*.spec.ts', 'tests/**'],
+    rules: {
+      'max-lines-per-function': 'off',
+      'max-lines': 'off',
+    },
+  },
 );
 `;


### PR DESCRIPTION
Closes #9.

The bundled `ESLINT_CONFIG_TEMPLATE` turned on `max-lines-per-function` and `max-lines` for every file, so a freshly scaffolded consumer's `eslint .` / `pnpm lint` fired on test files that habit-hooks itself exempts via `TEST_FILE_EXCLUDE`.

## Change
Append a test-file override block to the template using the same glob list as `TEST_FILE_EXCLUDE` (`['**/*.test.ts', '**/*.spec.ts', 'tests/**']`), turning the two size rules `off` so the init layer and the habit-hooks rule layer agree.

## Atomic commits
- `#9: exempt test files from size rules in init eslint template` — adds the override block and a test asserting the template embeds the glob list and the two `off` rules.

## Gates
- `pnpm build`, `pnpm lint` (eslint .) — clean
- `pnpm test` — 386 passed (+1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_