### PR TITLE
#20: align catalogue smell titles with docs/smell-vocabulary.md

### DIFF
--- a/src/config/catalogue.test.ts
+++ b/src/config/catalogue.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { defaultRules } from './catalogue.js';
+
+const vocabularyPath = join(dirname(fileURLToPath(import.meta.url)), '../../docs/smell-vocabulary.md');
+
+function parseCatalogueTitles(): Map<string, string> {
+  const lines = readFileSync(vocabularyPath, 'utf8').split('\n');
+  const titles = new Map<string, string>();
+  for (const line of lines) {
+    const match = line.match(/^\|\s*`([^`]+)`\s*\|\s*(.+?)\s*\|\s*\w+\s*\|$/);
+    if (match) titles.set(match[1], match[2]);
+  }
+  return titles;
+}
+
+describe('catalogue titles', () => {
+  const canonicalTitles = parseCatalogueTitles();
+
+  it('match the canonical titles in docs/smell-vocabulary.md', () => {
+    for (const rule of defaultRules) {
+      expect(canonicalTitles.get(rule.id), `no vocabulary entry for ${rule.id}`).toBeDefined();
+      expect(rule.title, `title drift for ${rule.id}`).toBe(canonicalTitles.get(rule.id));
+    }
+  });
+});

--- a/src/config/catalogue.ts
+++ b/src/config/catalogue.ts
@@ -65,7 +65,7 @@ const tier2Rules: Rule[] = [
     source: 'eslint',
     sourceRuleId: 'no-var',
     severity: 'enforced',
-    title: 'var declaration',
+    title: '`var` declaration',
     description: 'Use let or const; var hoists in surprising ways.',
   },
   {
@@ -89,7 +89,7 @@ const tier2Rules: Rule[] = [
     source: 'eslint',
     sourceRuleId: 'no-warning-comments',
     severity: 'suggested',
-    title: 'Warning comment',
+    title: 'Warning comment (TODO/FIXME/…)',
     description: 'TODO / FIXME / XXX / HACK markers are unfinished work in the codebase.',
   },
 ];
@@ -101,7 +101,7 @@ const tier3Rules: Rule[] = [
     sourceRuleId: '@typescript-eslint/no-explicit-any',
     severity: 'suggested',
     changedFilesOnly: true,
-    title: 'Explicit any',
+    title: 'Explicit `any`',
     description: 'any disables the type checker; prefer a precise type or unknown plus a narrow.',
   },
   {
@@ -129,7 +129,7 @@ const customRules: Rule[] = [
     source: 'custom',
     severity: 'suggested',
     changedFilesOnly: true,
-    title: 'Comment found',
+    title: 'Non-essential comment',
     description: 'Comments indicate code that is not self-documenting.',
   },
 ];


### PR DESCRIPTION
Closes #20.

Phase 1 copied catalogue titles verbatim from the old tool-keyed rules and deferred aligning them with the canonical `docs/smell-vocabulary.md` table. This reconciles them.

## Changes (atomic commits)
- `#20: align catalogue titles with docs/smell-vocabulary.md` — fixes the four drifted titles, content-only, no behavioural change:
  - `var-declaration`: `var declaration` → `` `var` declaration ``
  - `warning-comment`: `Warning comment` → `Warning comment (TODO/FIXME/…)`
  - `explicit-any`: `Explicit any` → `` Explicit `any` ``
  - `non-essential-comment`: `Comment found` → `Non-essential comment`
- `#20: gate catalogue titles against the vocabulary doc` — parses the doc's Catalogue table and asserts every `defaultRules` title matches, so future drift fails the suite.

## Notes
- No `severity` / `id` / `source` / `changedFilesOnly` fields touched — title-only.
- No CLI output snapshots needed updating; no test asserted these strings before.

## Gates
- `pnpm build`, `pnpm lint` — clean
- `pnpm test` — 386 passed (+1 new gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_