### PR TITLE
#14: de-flake `baseline generate is deterministic`

### DIFF
--- a/src/baseline/commands.test.ts
+++ b/src/baseline/commands.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createGitRepo, type GitRepo } from '../../tests/helpers/git.js';
 import {
@@ -48,19 +49,18 @@ describe('baseline generate', () => {
     expect(loaded.files['bad.ts'].snoozedAtCommit).toBe(lastCommitHash(repo.cwd, 'bad.ts'));
   });
 
-  it('is deterministic: running twice produces a byte-identical file', async () => {
-    repo = createGitRepo({ withEslint: true });
-    writeConfig(repo.cwd);
-    repo.writeFile('a-bad.ts', DIRTY_FN);
-    repo.writeFile('z-bad.ts', DIRTY_FN);
-    repo.writeFile('m-bad.ts', DIRTY_FN);
-    repo.commitAll('initial');
+  it('serializes a fixed violation set byte-identically regardless of entry order', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hh-baseline-det-'));
+    const hash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const entriesIn = (order: string[]) =>
+      Object.fromEntries(order.map((file) => [file, { snoozedAtCommit: hash }]));
 
-    await baselineGenerate(repo.cwd);
-    const first = readFileSync(join(repo.cwd, BASELINE_FILENAME), 'utf8');
-    await baselineGenerate(repo.cwd);
-    const second = readFileSync(join(repo.cwd, BASELINE_FILENAME), 'utf8');
+    saveBaseline(dir, { version: 2, files: entriesIn(['z-bad.ts', 'a-bad.ts', 'm-bad.ts']) });
+    const first = readFileSync(join(dir, BASELINE_FILENAME), 'utf8');
+    saveBaseline(dir, { version: 2, files: entriesIn(['m-bad.ts', 'z-bad.ts', 'a-bad.ts']) });
+    const second = readFileSync(join(dir, BASELINE_FILENAME), 'utf8');
 
+    rmSync(dir, { recursive: true, force: true });
     expect(second).toBe(first);
   });
 


### PR DESCRIPTION
Closes #14.

## Root cause
The test ran two full `baselineGenerate` passes, each spawning eslint. The wrap layer is fail-soft — a slow/failed spawn under CI load surfaces as zero violations — so the two passes could record different violation sets and the `byte-identical` assertion failed intermittently (Linux/CI only).

## Fix (locked decision — option a)
Assert serialization determinism over a **fixed/injected violation set**: drive `saveBaseline` directly with stubbed violations in two different insertion orders and assert the written files are byte-identical. This verifies exactly what the test name claims — deterministic serialization (the `sortedEntries` sort in `store.ts`) — with **no live multi-process spawns**.

No distinct coverage is lost: entry population, per-file recording, and merge-with-existing behaviour remain covered by the sibling tests in the same describe block. Ran the new test 5× — green every time.

## Atomic commits
- `#14: de-flake baseline determinism test with a fixed violation set`

## Gates
- `pnpm build`, `pnpm lint` — clean
- `pnpm test` — 385 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_