### PR TITLE
#8: scope.exclude config knob for discoverFiles

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -278,3 +278,9 @@ phases (PR #13). Each call below is an _agent decision_.
   only remaining `rules` usages are the tests that intentionally cover the alias
   and its precedence. **Scheduled follow-up:** a later issue removes the `rules`
   field from the schema/merge entirely (the hard removal).
+
+- **File discovery lives in its own module.** _(agent decision, #8)_ `FILE_GLOBS`
+  and `discoverFiles` moved out of `runner.ts` into `src/discover.ts`. `runner.ts`
+  sat exactly at the `max-lines: 200` limit, and discovery is a distinct
+  responsibility from orchestration; the move keeps runner under the cap and gives
+  the `scope.exclude` knob a focused home. Reversible — it could be inlined back.

--- a/habit-hooks.config.js
+++ b/habit-hooks.config.js
@@ -1,4 +1,7 @@
 export default {
+  scope: {
+    exclude: ['tests/fixtures/**'],
+  },
   smells: {
     'non-essential-comment': {
       exclude: ['tests/fixtures/**', 'habit-hooks.config.*'],

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -22,6 +22,7 @@ export interface ScopeConfig {
   autoBranchOffMain?: boolean;
   branchBase?: string;
   mainBranch?: string;
+  exclude?: string[];
 }
 
 export interface CommentCheckConfig {

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -99,6 +99,7 @@ function validateScope(value: unknown): ScopeConfig | undefined {
   validateOptionalBoolean(value.autoBranchOffMain, 'scope.autoBranchOffMain');
   validateOptionalString(value.branchBase, 'scope.branchBase');
   validateOptionalString(value.mainBranch, 'scope.mainBranch');
+  validateOptionalStringArray(value.exclude, 'scope.exclude');
   return value as ScopeConfig;
 }
 

--- a/src/discover-files.test.ts
+++ b/src/discover-files.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { discoverFiles } from './discover.js';
+
+function write(dir: string, rel: string): void {
+  const path = join(dir, rel);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, 'export const x = 1;\n');
+}
+
+describe('discoverFiles', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'hh-discover-'));
+    write(cwd, 'a.ts');
+    write(cwd, 'sub/b.ts');
+    write(cwd, 'fixtures/bad.ts');
+    write(cwd, 'node_modules/dep/c.ts');
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('ignores the built-in set and keeps everything else by default', async () => {
+    const files = await discoverFiles(cwd, 'typescript');
+    expect(files.map((file) => relative(cwd, file)).sort()).toEqual([
+      'a.ts',
+      'fixtures/bad.ts',
+      'sub/b.ts',
+    ]);
+  });
+
+  it('also skips paths matched by scope.exclude', async () => {
+    const files = await discoverFiles(cwd, 'typescript', ['fixtures/**']);
+    expect(files.map((file) => relative(cwd, file)).sort()).toEqual(['a.ts', 'sub/b.ts']);
+  });
+});

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -6,11 +6,15 @@ const FILE_GLOBS: Record<Language, string[]> = {
   python: ['**/*.py'],
 };
 
-export async function discoverFiles(cwd: string, language: Language): Promise<string[]> {
+export async function discoverFiles(
+  cwd: string,
+  language: Language,
+  exclude: string[] = [],
+): Promise<string[]> {
   return fg(FILE_GLOBS[language], {
     cwd,
     absolute: true,
-    ignore: ['**/node_modules/**', '**/dist/**', '**/coverage/**'],
+    ignore: ['**/node_modules/**', '**/dist/**', '**/coverage/**', ...exclude],
     dot: false,
   });
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,0 +1,16 @@
+import fg from 'fast-glob';
+import type { Language } from './config/schema.js';
+
+const FILE_GLOBS: Record<Language, string[]> = {
+  typescript: ['**/*.{ts,tsx,js,mjs,cjs}'],
+  python: ['**/*.py'],
+};
+
+export async function discoverFiles(cwd: string, language: Language): Promise<string[]> {
+  return fg(FILE_GLOBS[language], {
+    cwd,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/dist/**', '**/coverage/**'],
+    dot: false,
+  });
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,6 @@
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
-import fg from 'fast-glob';
 import picomatch from 'picomatch';
+import { discoverFiles } from './discover.js';
 import { loadConfig, loadConfigFromPath, RULES_DEPRECATION } from './config/load.js';
 import { buildRules } from './rules/registry.js';
 import { lookupPrompt } from './prompts/registry.js';
@@ -42,20 +42,6 @@ interface RunContext {
   language: Language;
   promptsDir?: string;
   configWarnings: string[];
-}
-
-const FILE_GLOBS: Record<Language, string[]> = {
-  typescript: ['**/*.{ts,tsx,js,mjs,cjs}'],
-  python: ['**/*.py'],
-};
-
-async function discoverFiles(cwd: string, language: Language): Promise<string[]> {
-  return fg(FILE_GLOBS[language], {
-    cwd,
-    absolute: true,
-    ignore: ['**/node_modules/**', '**/dist/**', '**/coverage/**'],
-    dot: false,
-  });
 }
 
 function buildMatcher(patterns: string[] | undefined): ((_path: string) => boolean) | null {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -106,7 +106,7 @@ async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: Ru
   const { config, configDir } = await resolveConfig(cwd, options);
   const rules = buildRules(config, configDir);
   const language: Language = config.language ?? 'typescript';
-  const files = await discoverFiles(cwd, language);
+  const files = await discoverFiles(cwd, language, config.scope?.exclude);
   const scope = resolveScope(options.scopeFlags ?? {}, config.scope, cwd);
   const baseline = resolveBaseline(cwd, options);
   const promptsDir = resolvePromptsDir(config, configDir);


### PR DESCRIPTION
Closes #8.

`discoverFiles` used a hardcoded ignore set (`node_modules`, `dist`, `coverage`) and swept `tests/fixtures/**`, so a self-run tripped 26 `eslint:fatal` violations on the fixture subtree (which has its own tsconfig).

## Fix (locked decision — option b)
Add an explicit `scope.exclude: string[]` config knob, unioned onto the built-in ignore set in `discoverFiles`. Not `.gitignore`-based. Default behaviour unchanged when unset. The repo's own config now sets `scope.exclude: ['tests/fixtures/**']`, and `node dist/cli.js --all` reports **0** fixture violations.

## Atomic commits
1. `#8: extract file discovery into its own module` — pure move of `FILE_GLOBS` + `discoverFiles` from `runner.ts` (which was at the `max-lines: 200` limit) into `src/discover.ts`. No behaviour change.
2. `#8: add scope.exclude knob honored by discoverFiles` — schema field + validation + `exclude` param unioned onto the ignore set + wiring + repo config + a test pinning both the exclude and the unchanged default.
3. `#8: record file-discovery extraction in DECISIONS.md`

## Gates
- `pnpm build`, `pnpm lint` — clean (runner.ts back under 200 lines)
- `pnpm test` — 387 passed (+2 new)
- Self-run `node dist/cli.js --all` — 0 `tests/fixtures` violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_