### PR TITLE
#12: memoize and batch the baseline git queries

### DIFF
--- a/src/baseline/filter.test.ts
+++ b/src/baseline/filter.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { createGitRepo, type GitRepo } from '../../tests/helpers/git.js';
 import { lastCommitHash } from './file-hash.js';
 import { partitionBySnooze } from './filter.js';
+import { createSnoozeIndex } from './snooze-index.js';
 import type { BaselineFile } from './store.js';
 
 function baselineWith(files: Record<string, string>): BaselineFile {
@@ -29,7 +30,7 @@ describe('partitionBySnooze (four-quadrant)', () => {
     const baseline = baselineWith({ 'a.ts': hash ?? '' });
     const abs = join(repo.cwd, 'a.ts');
 
-    const { active, skipped } = partitionBySnooze([abs], baseline, repo.cwd);
+    const { active, skipped } = partitionBySnooze([abs], baseline, createSnoozeIndex(repo.cwd));
 
     expect(skipped).toEqual([abs]);
     expect(active).toEqual([]);
@@ -44,7 +45,7 @@ describe('partitionBySnooze (four-quadrant)', () => {
     const baseline = baselineWith({ 'a.ts': hash ?? '' });
     const abs = join(repo.cwd, 'a.ts');
 
-    const { active, skipped } = partitionBySnooze([abs], baseline, repo.cwd);
+    const { active, skipped } = partitionBySnooze([abs], baseline, createSnoozeIndex(repo.cwd));
 
     expect(active).toEqual([abs]);
     expect(skipped).toEqual([]);
@@ -60,7 +61,7 @@ describe('partitionBySnooze (four-quadrant)', () => {
     const baseline = baselineWith({ 'a.ts': oldHash ?? '' });
     const abs = join(repo.cwd, 'a.ts');
 
-    const { active, skipped } = partitionBySnooze([abs], baseline, repo.cwd);
+    const { active, skipped } = partitionBySnooze([abs], baseline, createSnoozeIndex(repo.cwd));
 
     expect(active).toEqual([abs]);
     expect(skipped).toEqual([]);
@@ -73,7 +74,7 @@ describe('partitionBySnooze (four-quadrant)', () => {
     const baseline = baselineWith({});
     const abs = join(repo.cwd, 'a.ts');
 
-    const { active, skipped } = partitionBySnooze([abs], baseline, repo.cwd);
+    const { active, skipped } = partitionBySnooze([abs], baseline, createSnoozeIndex(repo.cwd));
 
     expect(active).toEqual([abs]);
     expect(skipped).toEqual([]);
@@ -99,7 +100,7 @@ describe('partitionBySnooze (four-quadrant)', () => {
       join(repo.cwd, 'not-snoozed.ts'),
     ];
 
-    const { active, skipped } = partitionBySnooze(inputs, baseline, repo.cwd);
+    const { active, skipped } = partitionBySnooze(inputs, baseline, createSnoozeIndex(repo.cwd));
 
     expect(skipped).toEqual([join(repo.cwd, 'snoozed-clean.ts')]);
     expect(active.sort()).toEqual(

--- a/src/baseline/filter.ts
+++ b/src/baseline/filter.ts
@@ -1,18 +1,9 @@
 import { relative, sep } from 'node:path';
-import { isWorkingTreeCleanFor, lastCommitHash } from './file-hash.js';
+import type { SnoozeIndex } from './snooze-index.js';
 import type { BaselineFile } from './store.js';
 
 export function toRepoRelative(cwd: string, absPath: string): string {
   return relative(cwd, absPath).split(sep).join('/');
-}
-
-function isSnoozed(relPath: string, baseline: BaselineFile, cwd: string): boolean {
-  const entry = baseline.files[relPath];
-  if (entry === undefined) return false;
-  const currentHash = lastCommitHash(cwd, relPath);
-  if (currentHash === null) return false;
-  if (currentHash !== entry.snoozedAtCommit) return false;
-  return isWorkingTreeCleanFor(cwd, relPath);
 }
 
 interface SnoozePartition {
@@ -32,12 +23,11 @@ function assignToPartition(
 export function partitionBySnooze(
   files: string[],
   baseline: BaselineFile,
-  cwd: string,
+  index: SnoozeIndex,
 ): SnoozePartition {
   const partition: SnoozePartition = { active: [], skipped: [] };
   for (const abs of files) {
-    const rel = toRepoRelative(cwd, abs);
-    assignToPartition(partition, abs, isSnoozed(rel, baseline, cwd));
+    assignToPartition(partition, abs, index.isSnoozed(abs, baseline));
   }
   return partition;
 }

--- a/src/baseline/snooze-index.test.ts
+++ b/src/baseline/snooze-index.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { gitExec } from '../git/exec.js';
+import { createSnoozeIndex } from './snooze-index.js';
+import type { BaselineFile } from './store.js';
+
+vi.mock('../git/exec.js', () => ({
+  gitExec: vi.fn(),
+  GitError: class GitError extends Error {},
+}));
+
+const mockGit = vi.mocked(gitExec);
+
+function baselineWith(files: Record<string, string>): BaselineFile {
+  const out: BaselineFile['files'] = {};
+  for (const [path, hash] of Object.entries(files)) out[path] = { snoozedAtCommit: hash };
+  return { version: 2, files: out };
+}
+
+describe('createSnoozeIndex', () => {
+  beforeEach(() => {
+    mockGit.mockReset();
+  });
+
+  function callCounts(): { status: number; log: number } {
+    const calls = mockGit.mock.calls.map((c) => c[0][0]);
+    return {
+      status: calls.filter((arg) => arg === 'status').length,
+      log: calls.filter((arg) => arg === 'log').length,
+    };
+  }
+
+  it('runs one whole-tree status and memoizes log across many isSnoozed calls', () => {
+    mockGit.mockImplementation((args) => (args[0] === 'log' ? 'abc123\n' : ''));
+    const baseline = baselineWith({ 'a.ts': 'abc123', 'b.ts': 'abc123' });
+    const index = createSnoozeIndex('/repo');
+
+    for (let rule = 0; rule < 9; rule += 1) {
+      index.isSnoozed('/repo/a.ts', baseline);
+      index.isSnoozed('/repo/b.ts', baseline);
+    }
+
+    const counts = callCounts();
+    expect(counts.status).toBe(1);
+    expect(counts.log).toBe(2);
+  });
+
+  it('treats a file listed by git status as dirty (not snoozed)', () => {
+    mockGit.mockImplementation((args) => {
+      if (args[0] === 'log') return 'abc123\n';
+      return ' M a.ts\0';
+    });
+    const index = createSnoozeIndex('/repo');
+    expect(index.isSnoozed('/repo/a.ts', baselineWith({ 'a.ts': 'abc123' }))).toBe(false);
+  });
+
+  it('treats both sides of a rename as dirty', () => {
+    mockGit.mockImplementation((args) => {
+      if (args[0] === 'log') return 'abc123\n';
+      return 'R  new.ts\0old.ts\0';
+    });
+    const index = createSnoozeIndex('/repo');
+    expect(index.isSnoozed('/repo/old.ts', baselineWith({ 'old.ts': 'abc123' }))).toBe(false);
+  });
+
+  it('is not snoozed when the entry hash no longer matches HEAD', () => {
+    mockGit.mockImplementation((args) => (args[0] === 'log' ? 'newhash\n' : ''));
+    const index = createSnoozeIndex('/repo');
+    expect(index.isSnoozed('/repo/a.ts', baselineWith({ 'a.ts': 'oldhash' }))).toBe(false);
+  });
+});

--- a/src/baseline/snooze-index.ts
+++ b/src/baseline/snooze-index.ts
@@ -1,0 +1,69 @@
+import { gitExec, GitError } from '../git/exec.js';
+import { lastCommitHash } from './file-hash.js';
+import { toRepoRelative } from './filter.js';
+import type { BaselineFile } from './store.js';
+
+// A per-run cache of the git queries the snooze check needs. The whole-tree
+// dirty set comes from one `git status` (not one spawn per file), and
+// last-commit hashes are memoized, collapsing the old O(rules x baseline-files)
+// git spawns to O(1) status + O(baseline-files) log calls per run.
+export interface SnoozeIndex {
+  isSnoozed(_absPath: string, _baseline: BaselineFile): boolean;
+}
+
+// `git status --porcelain -z` record: `XY <path>`, NUL-separated, no path
+// quoting. A rename/copy record is followed by an extra field for the original
+// path; both sides count as dirty. Returns the index of the last field consumed.
+function parseDirtyRecord(records: string[], i: number, dirty: Set<string>): number {
+  const record = records[i];
+  if (record.length < 4) return i;
+  dirty.add(record.slice(3));
+  if (!/[RC]/.test(record.slice(0, 2))) return i;
+  if (records[i + 1]) dirty.add(records[i + 1]);
+  return i + 1;
+}
+
+function computeDirtySet(cwd: string): Set<string> | null {
+  let records: string[];
+  try {
+    records = gitExec(['status', '--porcelain', '-z'], cwd).split('\0');
+  } catch (err) {
+    if (err instanceof GitError) return null;
+    throw err;
+  }
+  const dirty = new Set<string>();
+  for (let i = 0; i < records.length; i += 1) i = parseDirtyRecord(records, i, dirty);
+  return dirty;
+}
+
+class GitSnoozeIndex implements SnoozeIndex {
+  private readonly cwd: string;
+  private readonly hashes = new Map<string, string | null>();
+  private dirty: Set<string> | null | undefined;
+
+  constructor(cwd: string) {
+    this.cwd = cwd;
+  }
+
+  private hashFor(rel: string): string | null {
+    if (!this.hashes.has(rel)) this.hashes.set(rel, lastCommitHash(this.cwd, rel));
+    return this.hashes.get(rel) ?? null;
+  }
+
+  private isClean(rel: string): boolean {
+    if (this.dirty === undefined) this.dirty = computeDirtySet(this.cwd);
+    return this.dirty !== null && !this.dirty.has(rel);
+  }
+
+  isSnoozed(absPath: string, baseline: BaselineFile): boolean {
+    const rel = toRepoRelative(this.cwd, absPath);
+    const entry = baseline.files[rel];
+    if (entry === undefined) return false;
+    if (this.hashFor(rel) !== entry.snoozedAtCommit) return false;
+    return this.isClean(rel);
+  }
+}
+
+export function createSnoozeIndex(cwd: string): SnoozeIndex {
+  return new GitSnoozeIndex(cwd);
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,6 +8,7 @@ import { resolvePackagedDir } from './prompts/packaged-dir.js';
 import { resolveScope, type ResolvedScope, type ScopeFlags } from './git/resolve-scope.js';
 import { loadBaseline, type BaselineFile } from './baseline/store.js';
 import { partitionBySnooze } from './baseline/filter.js';
+import { createSnoozeIndex, type SnoozeIndex } from './baseline/snooze-index.js';
 import { SensorRunner } from './sensors/runner.js';
 import { buildPresetSensors, issueToViolation, violationToIssue } from './sensors/preset.js';
 import { buildPythonPresetSensors } from './sensors/python-preset.js';
@@ -37,6 +38,7 @@ interface RunContext {
   files: string[];
   scope: ResolvedScope;
   baseline: BaselineFile | null;
+  snoozeIndex: SnoozeIndex;
   language: Language;
   promptsDir?: string;
   configWarnings: string[];
@@ -82,7 +84,7 @@ function applyScopeToRule(rule: Rule, files: string[], scope: ResolvedScope): st
 
 function applyBaselineToRule(files: string[], ctx: RunContext): string[] {
   if (ctx.baseline === null) return files;
-  return partitionBySnooze(files, ctx.baseline, ctx.cwd).active;
+  return partitionBySnooze(files, ctx.baseline, ctx.snoozeIndex).active;
 }
 
 function resolveFilesForRule(rule: Rule, ctx: RunContext): string[] {
@@ -123,7 +125,8 @@ async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: Ru
   const baseline = resolveBaseline(cwd, options);
   const promptsDir = resolvePromptsDir(config, configDir);
   const configWarnings = config.rules !== undefined ? [RULES_DEPRECATION] : [];
-  return { ctx: { cwd, files, scope, baseline, language, promptsDir, configWarnings }, rules };
+  const snoozeIndex = createSnoozeIndex(cwd);
+  return { ctx: { cwd, files, scope, baseline, snoozeIndex, language, promptsDir, configWarnings }, rules };
 }
 
 // A sensor runs only when at least one smell it produces has an active rule

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -158,15 +158,11 @@ async function detect(ctx: RunContext, rules: Rule[]): Promise<{ violations: Vio
   return { violations: issues.map(issueToViolation), notices };
 }
 
-function allowedFilesBySmell(rules: Rule[], ctx: RunContext): Map<string, Set<string>> {
-  return new Map(rules.map((rule) => [rule.id, new Set(resolveFilesForRule(rule, ctx))] as const));
-}
-
 // Keep a violation when its smell has no rule (uncoached), or its file is not a
 // discovered source file (a project-level artifact like pyproject.toml reported
 // by a whole-project sensor), or its file is in the rule's resolved set.
 function filterViolations(violations: Violation[], rules: Rule[], ctx: RunContext): Violation[] {
-  const allowed = allowedFilesBySmell(rules, ctx);
+  const allowed = new Map(rules.map((rule) => [rule.id, new Set(resolveFilesForRule(rule, ctx))] as const));
   const sourceFiles = new Set(ctx.files);
   return violations.filter((v) => {
     const set = allowed.get(v.ruleId);


### PR DESCRIPTION
Closes #12.

The baseline snooze check ran `git log` + `git status` **per file, per rule, with no caching** — ~1,700 synchronous git spawns and ~117s wall-clock on a 110-entry baseline × 9 rules, where the actual tools take ~5.5s.

## Fix (locked decision — memoize AND batch)
A per-run `SnoozeIndex` (`src/baseline/snooze-index.ts`), built once in `buildContext` and threaded through `partitionBySnooze`:
- **Batch:** one whole-tree `git status --porcelain -z` builds the dirty set (replacing per-file `git status -- path`).
- **Memoize:** `lastCommitHash` is cached per relative path across rules.

This collapses the spawns to **O(1) status + O(baseline-files) log** per run.

## Parity
Behaviour (which files are snoozed) is unchanged — the existing four-quadrant `partitionBySnooze` tests now drive the real-git path through the index. Git-failure → all dirty (matches old `isWorkingTreeCleanFor` returning false). The `-z` parser covers both sides of a rename/copy.

## Atomic commits
1. `#12: add a memoized, batched snooze index` — the index + unit tests (incl. a spawn-count assertion: 9 rules × 2 files → exactly 1 status + 2 log).
2. `#12: drive the snooze check through the per-run index` — `partitionBySnooze(files, baseline, index)`, runner threading, updated filter tests. (Also collapses `allowedFilesBySmell` to stay under the line cap.)

## Gates
- `pnpm build`, `pnpm lint` — clean (runner.ts at the 200 cap)
- `pnpm test` — 389 passed (+4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_