### PR TITLE
#21: deprecation warning for the `rules` config alias

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -267,3 +267,14 @@ phases (PR #13). Each call below is an _agent decision_.
   even with the flag. A failed install is reported and never aborts the rest or
   changes the exit code. Lifting the ruff.toml boundary (needs a TOML library)
   is a deferred follow-up.
+
+## Issue-wrapup loop (GOAL #27)
+
+- **The `rules` config alias is deprecated, not yet removed.** _(agent decision,
+  #21)_ Per the one-release migration plan, `rules` is still accepted and folded
+  (with `smells` winning on conflict), but a run whose config uses `rules` now
+  emits `RULES_DEPRECATION` on stderr (detected in `buildContext`, surfaced via
+  `RunResult.stderr`). All internal test configs were migrated to `smells`; the
+  only remaining `rules` usages are the tests that intentionally cover the alias
+  and its precedence. **Scheduled follow-up:** a later issue removes the `rules`
+  field from the schema/merge entirely (the hard removal).

--- a/src/baseline/commands.test.ts
+++ b/src/baseline/commands.test.ts
@@ -22,7 +22,7 @@ const CLEAN_FN = `export function add(a: number, b: number): number {
 `;
 
 function writeConfig(cwd: string): void {
-  const cfg = { rules: { 'oversized-function': { disabled: true } } };
+  const cfg = { smells: { 'oversized-function': { disabled: true } } };
   writeFileSync(join(cwd, 'habit-hooks.config.json'), JSON.stringify(cfg));
 }
 
@@ -68,7 +68,7 @@ describe('baseline generate', () => {
     repo = createGitRepo({ withEslint: true });
     const cfg = {
       scope: { onlyChangedFiles: true },
-      rules: {
+      smells: {
         'too-many-parameters': { changedFilesOnly: true },
         'oversized-function': { disabled: true },
       },

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -122,7 +122,7 @@ describe('cli', () => {
       repo = createGitRepo({ withEslint: true });
       const cfg = {
         scope: { branchBase: 'main' },
-        rules: { 'oversized-function': { disabled: true } },
+        smells: { 'oversized-function': { disabled: true } },
       };
       writeFileSync(join(repo.cwd, 'habit-hooks.config.json'), JSON.stringify(cfg));
       repo.commitAll('initial config');

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -17,6 +17,9 @@ interface LoadedConfig {
   sourcePath: string | null;
 }
 
+export const RULES_DEPRECATION =
+  "habit-hooks: config field 'rules' is deprecated — rename it to 'smells'. Support for 'rules' will be removed in a future release.";
+
 function findConfigFile(cwd: string): string | null {
   for (const name of CONFIG_FILENAMES) {
     const candidate = join(cwd, name);

--- a/src/config/rules-deprecation.test.ts
+++ b/src/config/rules-deprecation.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { run } from '../runner.js';
+import { RULES_DEPRECATION } from './load.js';
+
+describe('rules alias deprecation', () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeConfig(value: unknown): void {
+    dir = mkdtempSync(join(tmpdir(), 'hh-deprecation-'));
+    writeFileSync(join(dir, 'habit-hooks.config.json'), JSON.stringify(value));
+  }
+
+  it('warns on stderr when a config uses the deprecated rules field', async () => {
+    writeConfig({ rules: { 'oversized-function': { disabled: true } } });
+    const result = await run(dir);
+    expect(result.stderr).toContain(RULES_DEPRECATION);
+  });
+
+  it('does not warn when a config uses smells', async () => {
+    writeConfig({ smells: { 'oversized-function': { disabled: true } } });
+    const result = await run(dir);
+    expect(result.stderr).not.toContain(RULES_DEPRECATION);
+  });
+});

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -83,7 +83,7 @@ describe('runner.run sensor gating', () => {
     writeFileSync(join(dir, 'a.ts'), LONG_COMMENT);
     writeFileSync(
       join(dir, 'habit-hooks.config.json'),
-      JSON.stringify({ rules: { 'non-essential-comment': { disabled: true } } }),
+      JSON.stringify({ smells: { 'non-essential-comment': { disabled: true } } }),
     );
 
     const result = await run(dir);
@@ -101,7 +101,7 @@ describe('runner.run with scope', () => {
 
   function writeConfig(cwd: string, changedFilesOnly: boolean): void {
     const cfg = {
-      rules: {
+      smells: {
         'too-many-parameters': { changedFilesOnly },
         'oversized-function': { disabled: true },
       },
@@ -155,7 +155,7 @@ describe('runner.run with scope', () => {
     repo = createGitRepo({ withEslint: true });
     const cfg = {
       scope: { onlyChangedFiles: true },
-      rules: {
+      smells: {
         'too-many-parameters': { changedFilesOnly: true },
         'oversized-function': { disabled: true },
       },
@@ -179,7 +179,7 @@ describe('runner.run with baseline', () => {
 
   function writeMaxParamsConfig(cwd: string): void {
     const cfg = {
-      rules: { 'oversized-function': { disabled: true } },
+      smells: { 'oversized-function': { disabled: true } },
     };
     writeFileSync(join(cwd, 'habit-hooks.config.json'), JSON.stringify(cfg));
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import fg from 'fast-glob';
 import picomatch from 'picomatch';
-import { loadConfig, loadConfigFromPath } from './config/load.js';
+import { loadConfig, loadConfigFromPath, RULES_DEPRECATION } from './config/load.js';
 import { buildRules } from './rules/registry.js';
 import { lookupPrompt } from './prompts/registry.js';
 import { resolvePackagedDir } from './prompts/packaged-dir.js';
@@ -39,6 +39,7 @@ interface RunContext {
   baseline: BaselineFile | null;
   language: Language;
   promptsDir?: string;
+  configWarnings: string[];
 }
 
 const FILE_GLOBS: Record<Language, string[]> = {
@@ -121,7 +122,8 @@ async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: Ru
   const scope = resolveScope(options.scopeFlags ?? {}, config.scope, cwd);
   const baseline = resolveBaseline(cwd, options);
   const promptsDir = resolvePromptsDir(config, configDir);
-  return { ctx: { cwd, files, scope, baseline, language, promptsDir }, rules };
+  const configWarnings = config.rules !== undefined ? [RULES_DEPRECATION] : [];
+  return { ctx: { cwd, files, scope, baseline, language, promptsDir, configWarnings }, rules };
 }
 
 // A sensor runs only when at least one smell it produces has an active rule
@@ -154,9 +156,7 @@ async function detect(ctx: RunContext, rules: Rule[]): Promise<{ violations: Vio
 }
 
 function allowedFilesBySmell(rules: Rule[], ctx: RunContext): Map<string, Set<string>> {
-  const map = new Map<string, Set<string>>();
-  for (const rule of rules) map.set(rule.id, new Set(resolveFilesForRule(rule, ctx)));
-  return map;
+  return new Map(rules.map((rule) => [rule.id, new Set(resolveFilesForRule(rule, ctx))] as const));
 }
 
 // Keep a violation when its smell has no rule (uncoached), or its file is not a
@@ -195,5 +195,6 @@ export async function run(cwd: string, options: RunOptions = {}): Promise<RunRes
   const dirs: MapperDirs = { overrideDir: ctx.promptsDir, packagedDir: resolvePackagedDir() };
   const mapped = mapIssues(violations.map(violationToIssue), buildRouting(rules), dirs);
   const rendered = guide({ result: mapped, dirs });
-  return { stdout: rendered.stdout, exitCode: rendered.exitCode, violations, stderr: detected.notices };
+  const stderr = [...ctx.configWarnings, ...detected.notices];
+  return { stdout: rendered.stdout, exitCode: rendered.exitCode, violations, stderr };
 }


### PR DESCRIPTION
Closes #21.

Phase 3a introduced the canonical `smells` config field but kept the old `rules` field as a transitional alias. Per the locked migration plan, this is the **one-release deprecation** step — not the hard removal.

## Locked decision — option (a)
- `rules` is **still accepted** (schema + merge unchanged; `smells` still wins on conflict).
- A config using `rules` now emits a clear deprecation warning on stderr (`RULES_DEPRECATION`), detected in `buildContext` and surfaced via `RunResult.stderr` (the CLI prints stderr).
- Internal incidental test configs migrated to `smells`; the alias-behavior tests (registry precedence, `load.test` loading/validation) intentionally keep `rules`.
- Hard removal scheduled as a later issue (noted in `DECISIONS.md`).

## Atomic commits
1. `#21: migrate internal test configs from rules to smells` — behaviour-preserving renames of the incidental `writeConfig` setups (eslint-config `rules` left untouched).
2. `#21: warn when a config uses the deprecated rules field` — the warning + a dedicated test asserting it fires for `rules` and not for `smells`, plus the DECISIONS note.

## Gates
- `pnpm build`, `pnpm lint` — clean (runner.ts at the 200 cap)
- `pnpm test` — 387 passed (+2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_