### PR TITLE
#17: needs-extraction composite (multi) sensor

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -318,3 +318,17 @@ phases (PR #13). Each call below is an _agent decision_.
   while every successful sensor's output still renders. The failure message stays
   in `notices` too, so display is unchanged. Reversible — the sink could collapse
   back to a bare notices array if the policy were reverted.
+
+- **`needs-extraction` is a real multi sensor; replace-mode runs in the sensor
+  stage.** _(agent decision, #17)_ The composite (`oversized-file` +
+  `duplicated-code` in one file → `needs-extraction`, enforced) is a genuine
+  multi sensor using `dependsOn`/`ctx.deps`; the mapper stays a pure single-smell
+  function. The augment-vs-replace switch (`needsExtraction.replace`, default
+  augment) is applied by `applyReplaceMode` in the sensor module, called from
+  `detect()` on the merged bag before the mapper — so combination logic stays in
+  the sensor layer. The composite is wired into the **TS preset only** for now,
+  because on `main` the Python preset has no `oversized-file` producer (that is
+  #19); `satisfiableSensors` drops a composite whose dependency producers were
+  gated out, so a config that disables an input can't crash the run. The
+  catalogue entry lives in `customRules` (source `custom`) to stay under the
+  200-line cap.

--- a/docs/smell-vocabulary.md
+++ b/docs/smell-vocabulary.md
@@ -38,6 +38,7 @@ exits 0. The mapper config can override it per project.
 | `redundant-type-annotation` | Redundant type annotation             | enforced         |
 | `non-essential-comment`     | Non-essential comment                 | suggested        |
 | `duplicated-code`           | Duplicated code                       | suggested        |
+| `needs-extraction`          | Needs extraction                      | enforced         |
 | `unused-class-member`       | Unused class member                   | enforced         |
 | `unused-file`               | Unused file                           | enforced         |
 | `unused-export`             | Unused export                         | enforced         |
@@ -97,6 +98,18 @@ the Python preset. `oversized-file` has no clean ruff rule, so the Python preset
 emits it from a language-agnostic line-count sensor whose threshold
 (`max-module-lines`, default 200) is read from the consumer's config text (see
 `DECISIONS.md`).
+
+## Combinations
+
+Some smells are **composite**: derived by a multi sensor from the co-occurrence
+of others, not from a tool (docs/architecture.md "Combinations"). `needs-extraction`
+fires when a single file has both `oversized-file` **and** `duplicated-code`. By
+default it **augments** (all three smells show); `needsExtraction.replace: true`
+suppresses the two input smells for that file so only `needs-extraction` remains.
+
+| Composite          | Derived from                          | Smell key          |
+|--------------------|---------------------------------------|--------------------|
+| same-file overlap  | `oversized-file` + `duplicated-code`  | `needs-extraction` |
 
 ## Uncoached smells
 

--- a/src/config/catalogue.ts
+++ b/src/config/catalogue.ts
@@ -1,9 +1,7 @@
 import type { Rule } from '../types.js';
 
-// The canonical, tool-independent smell catalogue (docs/smell-vocabulary.md):
-// default severity, title, and description per smell. Sensors translate raw tool
-// output into these keys; a rule here makes the smell coached and lets its
-// producing sensor activate. `source`/`sourceRuleId` are legacy provenance hints.
+// The canonical, tool-independent smell catalogue (docs/smell-vocabulary.md): a
+// rule here makes the smell coached and activates its producing sensor.
 
 const tier1Rules: Rule[] = [
   {
@@ -132,6 +130,14 @@ const customRules: Rule[] = [
     title: 'Non-essential comment',
     description: 'Comments indicate code that is not self-documenting.',
   },
+  {
+    id: 'needs-extraction',
+    source: 'custom',
+    severity: 'enforced',
+    changedFilesOnly: true,
+    title: 'Needs extraction',
+    description: 'A file that is both oversized and duplicated wants the shared block extracted.',
+  },
 ];
 
 const jscpdRules: Rule[] = [
@@ -145,8 +151,7 @@ const jscpdRules: Rule[] = [
   },
 ];
 
-// The "unused" family: knip emits these for TypeScript; deptry emits
-// unused-dependency and ruff emits unused-import for Python.
+// The "unused" family: knip (TS), deptry (unused-dependency), ruff (unused-import).
 const unusedRules: Rule[] = [
   {
     id: 'unused-class-member',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -30,6 +30,13 @@ export interface CommentCheckConfig {
   maxBlockChars?: number;
 }
 
+// When `replace` is true, a `needs-extraction` finding suppresses its two input
+// smells (oversized-file, duplicated-code) for that file. Default (augment)
+// shows all three.
+export interface NeedsExtractionConfig {
+  replace?: boolean;
+}
+
 export type Language = 'typescript' | 'python';
 
 export interface HabitHooksConfig {
@@ -42,6 +49,7 @@ export interface HabitHooksConfig {
   rules?: Record<string, RuleOverride | RuleDefinition>;
   scope?: ScopeConfig;
   commentCheck?: CommentCheckConfig;
+  needsExtraction?: NeedsExtractionConfig;
 }
 
 export function isRuleDefinition(

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -3,6 +3,7 @@ import type {
   CommentCheckConfig,
   HabitHooksConfig,
   Language,
+  NeedsExtractionConfig,
   RuleDefinition,
   RuleOverride,
   ScopeConfig,
@@ -126,6 +127,13 @@ function validateLanguage(value: unknown): Language | undefined {
   return value as Language;
 }
 
+function validateNeedsExtraction(value: unknown): NeedsExtractionConfig | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainObject(value)) fail('needsExtraction', 'an object');
+  validateOptionalBoolean(value.replace, 'needsExtraction.replace');
+  return value as NeedsExtractionConfig;
+}
+
 interface ValidatedParts {
   prompts?: string;
   language: Language | undefined;
@@ -133,6 +141,7 @@ interface ValidatedParts {
   rules: HabitHooksConfig['rules'];
   scope: ScopeConfig | undefined;
   commentCheck: CommentCheckConfig | undefined;
+  needsExtraction: NeedsExtractionConfig | undefined;
 }
 
 function assembleConfig(parts: ValidatedParts): HabitHooksConfig {
@@ -143,18 +152,24 @@ function assembleConfig(parts: ValidatedParts): HabitHooksConfig {
   if (parts.rules !== undefined) config.rules = parts.rules;
   if (parts.scope !== undefined) config.scope = parts.scope;
   if (parts.commentCheck !== undefined) config.commentCheck = parts.commentCheck;
+  if (parts.needsExtraction !== undefined) config.needsExtraction = parts.needsExtraction;
   return config;
 }
 
-export function validateConfig(value: unknown): HabitHooksConfig {
-  if (!isPlainObject(value)) fail('config', 'an object');
-  validateOptionalString(value.prompts, 'prompts');
-  return assembleConfig({
+function validateParts(value: Record<string, unknown>): ValidatedParts {
+  return {
     prompts: typeof value.prompts === 'string' ? value.prompts : undefined,
     language: validateLanguage(value.language),
     smells: validateEntryMap(value.smells, 'smells'),
     rules: validateEntryMap(value.rules, 'rules'),
     scope: validateScope(value.scope),
     commentCheck: validateCommentCheck(value.commentCheck),
-  });
+    needsExtraction: validateNeedsExtraction(value.needsExtraction),
+  };
+}
+
+export function validateConfig(value: unknown): HabitHooksConfig {
+  if (!isPlainObject(value)) fail('config', 'an object');
+  validateOptionalString(value.prompts, 'prompts');
+  return assembleConfig(validateParts(value));
 }

--- a/src/prompts/needs-extraction.md
+++ b/src/prompts/needs-extraction.md
@@ -1,0 +1,9 @@
+This file is **both** oversized and duplicated. Those two signals together point at one fix, and it is not "split the file in half."
+
+When a long file also repeats a block, the length is usually a *symptom*: the file has accreted a concept that wants its own home, and the duplication is that concept leaking out in two places. Splitting the file at the line threshold would scatter the duplication further; deduplicating in place would leave the bloated file just as incohesive. Do both at once, in the right order.
+
+Read the duplicated block first and name what it does in one sentence. That sentence is the missing module: extract the duplicated block into a shared unit (a small module, a class, a value object) with a focused interface — not a five-parameter helper that merely hides the lines.
+
+Then let that extraction *carry weight out of the file*. Move the related types and helpers that belong with the new abstraction along with it. Re-check the file size afterwards: a good extraction usually brings the file back under the threshold on its own, because the thing you pulled out was the reason it was too big.
+
+If the two copies are genuinely different ideas that only look alike, do not force a shared abstraction — extract along the real seams instead, and if the duplication is the lesser evil, snooze it with a note rather than distorting either side.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,7 +9,8 @@ import { resolveScope, type ResolvedScope, type ScopeFlags, type ScopeMode } fro
 import { loadBaseline, type BaselineFile } from './baseline/store.js';
 import { partitionBySnooze } from './baseline/filter.js';
 import { createSnoozeIndex, type SnoozeIndex } from './baseline/snooze-index.js';
-import { SensorRunner } from './sensors/runner.js';
+import { SensorRunner, satisfiableSensors } from './sensors/runner.js';
+import { applyReplaceMode } from './sensors/needs-extraction.js';
 import { buildPresetSensors, issueToViolation, violationToIssue } from './sensors/preset.js';
 import { buildPythonPresetSensors } from './sensors/python-preset.js';
 import { mapIssues, type MapperDirs, type RoutingLookup } from './mapper/mapper.js';
@@ -44,6 +45,7 @@ interface RunContext {
   language: Language;
   promptsDir?: string;
   configWarnings: string[];
+  needsExtractionReplace: boolean;
 }
 
 function applyScopeToRule(rule: Rule, files: string[], scope: ResolvedScope): string[] {
@@ -97,7 +99,8 @@ async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: Ru
   const promptsDir = resolvePromptsDir(config, configDir);
   const configWarnings = config.rules !== undefined ? [RULES_DEPRECATION] : [];
   const snoozeIndex = createSnoozeIndex(cwd);
-  return { ctx: { cwd, files, scope, baseline, snoozeIndex, language, promptsDir, configWarnings }, rules };
+  const needsExtractionReplace = config.needsExtraction?.replace === true;
+  return { ctx: { cwd, files, scope, baseline, snoozeIndex, language, promptsDir, configWarnings, needsExtractionReplace }, rules };
 }
 
 // A sensor runs only when at least one smell it produces has an active rule
@@ -124,9 +127,10 @@ async function detect(ctx: RunContext, rules: Rule[]): Promise<{ violations: Vio
   const sink: SensorSink = { notices: [], failures: [] };
   const rulesById = new Map(rules.map((r) => [r.id, r] as const));
   const all = presetSensors(ctx, rulesById, sink);
-  const active = all.filter((sensor) => sensorActive(sensor, rulesById, ctx));
+  const active = satisfiableSensors(all.filter((sensor) => sensorActive(sensor, rulesById, ctx)));
   const issues = await new SensorRunner(active).run({ files: ctx.files, cwd: ctx.cwd });
-  return { violations: issues.map(issueToViolation), sink };
+  const combined = applyReplaceMode(issues, ctx.needsExtractionReplace);
+  return { violations: combined.map(issueToViolation), sink };
 }
 
 // Keep a violation when its smell has no rule (uncoached), or its file is not a

--- a/src/sensors/needs-extraction.test.ts
+++ b/src/sensors/needs-extraction.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyReplaceMode, needsExtractionSensor } from './needs-extraction.js';
+import { satisfiableSensors } from './runner.js';
+import { run } from '../runner.js';
+import type { Issue, Sensor } from './types.js';
+
+function issue(smell: string, file: string): Issue {
+  return { smell, details: { file } };
+}
+
+describe('needsExtractionSensor', () => {
+  it('emits needs-extraction only for files with both inputs', async () => {
+    const deps = [
+      issue('oversized-file', '/a.ts'),
+      issue('duplicated-code', '/a.ts'),
+      issue('oversized-file', '/b.ts'),
+      issue('duplicated-code', '/c.ts'),
+    ];
+    const out = await needsExtractionSensor().run({ files: [], cwd: '/', deps });
+    expect(out.map((i) => i.details.file)).toEqual(['/a.ts']);
+    expect(out[0]?.smell).toBe('needs-extraction');
+  });
+});
+
+describe('applyReplaceMode', () => {
+  const issues = [
+    issue('needs-extraction', '/a.ts'),
+    issue('oversized-file', '/a.ts'),
+    issue('duplicated-code', '/a.ts'),
+    issue('oversized-file', '/b.ts'),
+  ];
+
+  it('augment (default) keeps every issue', () => {
+    expect(applyReplaceMode(issues, false)).toEqual(issues);
+  });
+
+  it('replace drops the input smells only for files with needs-extraction', () => {
+    expect(applyReplaceMode(issues, true).map((i) => `${i.smell}:${String(i.details.file)}`)).toEqual([
+      'needs-extraction:/a.ts',
+      'oversized-file:/b.ts',
+    ]);
+  });
+});
+
+describe('satisfiableSensors', () => {
+  const producer: Sensor = {
+    id: 'p',
+    produces: ['oversized-file', 'duplicated-code'],
+    run: () => Promise.resolve([]),
+  };
+
+  it('drops a multi sensor whose deps are not produced by another active sensor', () => {
+    expect(satisfiableSensors([needsExtractionSensor()])).toEqual([]);
+  });
+
+  it('keeps the multi sensor when both deps are produced', () => {
+    expect(satisfiableSensors([needsExtractionSensor(), producer]).map((s) => s.id)).toEqual([
+      'needs-extraction',
+      'p',
+    ]);
+  });
+});
+
+const BLOCK = `export function NAME(order) {
+  const tax = order.total * 0.1;
+  const shipping = order.total > 100 ? 0 : 10;
+  return order.total + tax + shipping;
+}
+`;
+
+describe('needs-extraction end-to-end', () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function setup(config?: unknown): void {
+    dir = mkdtempSync(join(tmpdir(), 'hh-needs-extraction-'));
+    writeFileSync(
+      join(dir, 'eslint.config.js'),
+      `export default [{ languageOptions: { sourceType: 'module', ecmaVersion: 2022 }, rules: { 'max-lines': ['error', { max: 8 }] } }];\n`,
+    );
+    writeFileSync(join(dir, '.jscpd.json'), JSON.stringify({ minTokens: 20, minLines: 2 }));
+    writeFileSync(join(dir, 'big.js'), BLOCK.replace('NAME', 'alpha') + BLOCK.replace('NAME', 'beta'));
+    if (config !== undefined) writeFileSync(join(dir, 'habit-hooks.config.json'), JSON.stringify(config));
+  }
+
+  function smellsOf(violations: { ruleId: string }[]): Set<string> {
+    return new Set(violations.map((v) => v.ruleId));
+  }
+
+  it('fires needs-extraction through the real runner and augments by default', async () => {
+    setup();
+    const smells = smellsOf((await run(dir)).violations);
+    expect(smells.has('needs-extraction')).toBe(true);
+    expect(smells.has('oversized-file')).toBe(true);
+    expect(smells.has('duplicated-code')).toBe(true);
+  }, 30_000);
+
+  it('replace mode suppresses the input smells for the combined file', async () => {
+    setup({ needsExtraction: { replace: true } });
+    const violations = (await run(dir)).violations;
+    expect(violations.filter((v) => v.ruleId === 'needs-extraction').length).toBeGreaterThan(0);
+    expect(violations.filter((v) => v.ruleId === 'oversized-file')).toEqual([]);
+    expect(violations.filter((v) => v.ruleId === 'duplicated-code')).toEqual([]);
+  }, 30_000);
+});

--- a/src/sensors/needs-extraction.ts
+++ b/src/sensors/needs-extraction.ts
@@ -1,0 +1,60 @@
+import type { Issue, Sensor } from './types.js';
+
+const SMELL = 'needs-extraction';
+const INPUT_SMELLS = ['oversized-file', 'duplicated-code'] as const;
+
+function fileOf(issue: Issue): string | null {
+  const file = issue.details.file;
+  return typeof file === 'string' ? file : null;
+}
+
+function filesWith(issues: Issue[], smell: string): Set<string> {
+  const files = new Set<string>();
+  for (const issue of issues) {
+    if (issue.smell !== smell) continue;
+    const file = fileOf(issue);
+    if (file !== null) files.add(file);
+  }
+  return files;
+}
+
+function needsExtractionIssue(file: string): Issue {
+  return {
+    smell: SMELL,
+    details: {
+      file,
+      line: 1,
+      column: 1,
+      message: 'File is both oversized and duplicated; extract the duplicated block into a shared module.',
+      source: 'composite:oversized-file+duplicated-code',
+    },
+  };
+}
+
+function combine(deps: Issue[]): Issue[] {
+  const duplicated = filesWith(deps, 'duplicated-code');
+  return [...filesWith(deps, 'oversized-file')].filter((file) => duplicated.has(file)).map(needsExtractionIssue);
+}
+
+// The composite sensor: a real multi sensor that reads oversized-file +
+// duplicated-code from ctx.deps and emits needs-extraction for any file that has
+// both (docs/architecture.md "Combinations"). All combination logic stays here
+// in the sensor layer; the mapper never sees it.
+export function needsExtractionSensor(): Sensor {
+  return {
+    id: SMELL,
+    produces: [SMELL],
+    dependsOn: [...INPUT_SMELLS],
+    run: (ctx) => Promise.resolve(combine(ctx.deps)),
+  };
+}
+
+// `replace` mode: once needs-extraction fires for a file, drop that file's two
+// input smells so only the consolidated finding shows. Default (augment) keeps
+// all three. Operates on the merged bag before the mapper runs.
+export function applyReplaceMode(issues: Issue[], replace: boolean): Issue[] {
+  if (!replace) return issues;
+  const extracted = filesWith(issues, SMELL);
+  const suppressed = new Set<string>(INPUT_SMELLS);
+  return issues.filter((issue) => !(suppressed.has(issue.smell) && extracted.has(fileOf(issue) ?? '')));
+}

--- a/src/sensors/preset.test.ts
+++ b/src/sensors/preset.test.ts
@@ -47,13 +47,16 @@ describe('issueToViolation', () => {
 });
 
 describe('buildPresetSensors', () => {
-  it('registers the four TS preset sensors with their smell keys', () => {
+  it('registers the TS preset sensors (incl. the needs-extraction composite) with their smell keys', () => {
     const sensors = buildPresetSensors({ sink: { notices: [], failures: [] } });
-    expect(sensors.map((s) => s.id)).toEqual(['eslint', 'comment', 'jscpd', 'knip']);
+    expect(sensors.map((s) => s.id)).toEqual(['eslint', 'comment', 'jscpd', 'knip', 'needs-extraction']);
     const eslint = sensors.find((s) => s.id === 'eslint');
     expect(eslint?.produces).toContain('too-many-parameters');
     expect(eslint?.produces).toContain('parse-error');
     expect(sensors.find((s) => s.id === 'jscpd')?.produces).toEqual(['duplicated-code']);
     expect(sensors.find((s) => s.id === 'comment')?.produces).toEqual(['non-essential-comment']);
+    const composite = sensors.find((s) => s.id === 'needs-extraction');
+    expect(composite?.produces).toEqual(['needs-extraction']);
+    expect(composite?.dependsOn).toEqual(['oversized-file', 'duplicated-code']);
   });
 });

--- a/src/sensors/preset.ts
+++ b/src/sensors/preset.ts
@@ -3,6 +3,7 @@ import { commentCheck } from '../checks/comment-check.js';
 import { jscpdWrap } from '../checks/jscpd-wrap.js';
 import { knipWrap } from '../checks/knip-wrap.js';
 import type { SensorSink } from '../wrap/notices.js';
+import { needsExtractionSensor } from './needs-extraction.js';
 import type { Check, CheckOutcome, Rule, Violation } from '../types.js';
 import type { Issue, Sensor } from './types.js';
 
@@ -76,8 +77,9 @@ function commentSensor(input: PresetInput): Sensor {
   return checkLeafSensor({ check: commentCheck, produces: ['non-essential-comment'], sink: input.sink, rules });
 }
 
-// The TypeScript/JavaScript preset: four leaf sensors over eslint, ts-morph
-// comments, jscpd, and knip.
+// The TypeScript/JavaScript preset: leaf sensors over eslint, ts-morph comments,
+// jscpd, and knip, plus the needs-extraction composite over oversized-file +
+// duplicated-code.
 export function buildPresetSensors(input: PresetInput): Sensor[] {
   const { sink } = input;
   return [
@@ -85,5 +87,6 @@ export function buildPresetSensors(input: PresetInput): Sensor[] {
     commentSensor(input),
     checkLeafSensor({ check: jscpdWrap, produces: ['duplicated-code'], sink }),
     checkLeafSensor({ check: knipWrap, produces: KNIP_PRODUCES, sink }),
+    needsExtractionSensor(),
   ];
 }

--- a/src/sensors/runner.ts
+++ b/src/sensors/runner.ts
@@ -34,6 +34,18 @@ function dependencyKeys(sensor: Sensor): string[] {
   return sensor.dependsOn ?? [];
 }
 
+// Drop a multi sensor whose depended-on smells are not produced by any other
+// sensor in the set — e.g. a composite whose inputs were gated out by config.
+// This keeps SensorRunner construction (which throws on unproduced deps) from
+// crashing a run when a dependency producer is simply inactive.
+export function satisfiableSensors(sensors: Sensor[]): Sensor[] {
+  return sensors.filter((sensor) => {
+    const others = sensors.filter((other) => other.id !== sensor.id);
+    const produced = new Set(others.flatMap((other) => other.produces));
+    return dependencyKeys(sensor).every((smell) => produced.has(smell));
+  });
+}
+
 function assertSatisfiable(sensor: Sensor, producers: Map<string, Sensor[]>): void {
   for (const smell of dependencyKeys(sensor)) {
     const others = (producers.get(smell) ?? []).filter((p) => p.id !== sensor.id);


### PR DESCRIPTION
Closes #17.

Ships the first **composite/multi sensor** described in `docs/architecture.md`: `oversized-file` + `duplicated-code` in the **same file** → `needs-extraction`.

## Locked decisions
- **17.1:** same-file `oversized-file` + `duplicated-code` → `needs-extraction`.
- **17.2:** configurable; **default augment** (all three show). `needsExtraction.replace: true` suppresses the two input smells for that file.
- **17.3:** severity **enforced**.
- **17.4:** ROSE-pattern `needs-extraction.md` prompt.

## Hard constraints — all met
- A **real multi sensor** via `dependsOn`/`ctx.deps`; the **mapper is untouched** and stays a pure single-smell function. Replace-mode (`applyReplaceMode`) runs in the sensor layer (`detect()` on the merged bag).
- Fires **end-to-end through the real runner** on a fixture that trips both inputs (bundled eslint `max-lines` + jscpd duplication, plain-JS so no `node_modules` needed).
- `needs-extraction` added to `docs/smell-vocabulary.md` (+ a Combinations section).

## Notes
- Wired into the **TS preset only** for now — on `main` the Python preset has no `oversized-file` producer (that's #19). `satisfiableSensors` drops a composite whose dependency producers were gated out (e.g. a config that disables an input), so the run can't crash.

## Atomic commits
1. `#17: add the needs-extraction composite sensor and a satisfiability prune`
2. `#17: catalogue, prompt, and config for needs-extraction`
3. `#17: wire needs-extraction into the TS preset end-to-end`

## Gates
- `pnpm build`, `pnpm lint` — clean
- `pnpm test` — 392 passed (+7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_