### PR TITLE
#24: make runner/sensor/registry smell-agnostic (config-driven)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -332,3 +332,17 @@ phases (PR #13). Each call below is an _agent decision_.
   gated out, so a config that disables an input can't crash the run. The
   catalogue entry lives in `customRules` (source `custom`) to stay under the
   200-line cap.
+
+- **Smell knowledge lives only in config; the sensor layer consumes it.** _(agent
+  decision, #24)_ All tool/smell mappings moved to `src/config/tool-smells.ts`:
+  the eslint raw→smell map, eslint/knip/jscpd/comment produces, and the ruff +
+  deptry `AdapterSpec`s. The eslint/jscpd/comment data is **derived from the
+  catalogue** (so adding a smell there auto-wires its translation and produces);
+  knip's raw issue types and the supplemental `parse-error` (an eslint fatal with
+  no catalogue rule) are the config literals. The runner, sensors, checks, and
+  rules registry now import these instead of hardcoding — the acceptance grep is
+  clean for non-test source. (Test files still pin concrete smell strings as
+  behaviour assertions.) Adding a new eslint smell touches only `src/config/`
+  (catalogue) + `src/cli/init/` (the scaffolded eslint config) — proved live by
+  the `deep-nesting` smell (#26). Realizes the locked "spec from config" via
+  config-derived constants rather than per-call DI, keeping the refactor low-risk.

--- a/src/checks/comment-check.ts
+++ b/src/checks/comment-check.ts
@@ -1,4 +1,5 @@
 import { Project, SyntaxKind, type Node, type SourceFile } from 'ts-morph';
+import { COMMENT_SMELL } from '../config/tool-smells.js';
 import type { Check, CommentCheckThresholds, Rule, Violation } from '../types.js';
 
 export const DEFAULT_COMMENT_CHECK_THRESHOLDS: CommentCheckThresholds = {
@@ -31,7 +32,7 @@ function truncate(text: string): string {
 
 function makeViolation(file: string, comment: Node, kind: CommentKind): Violation {
   return {
-    ruleId: 'non-essential-comment',
+    ruleId: COMMENT_SMELL,
     source: 'comment:non-essential',
     file,
     line: comment.getStartLineNumber(),
@@ -80,7 +81,7 @@ function buildProject(files: string[]): Project {
 }
 
 function resolveThresholds(rules: Rule[]): CommentCheckThresholds {
-  const rule = rules.find((r) => r.id === 'non-essential-comment');
+  const rule = rules.find((r) => r.id === COMMENT_SMELL);
   return rule?.commentCheck ?? DEFAULT_COMMENT_CHECK_THRESHOLDS;
 }
 

--- a/src/checks/eslint-wrap.ts
+++ b/src/checks/eslint-wrap.ts
@@ -13,6 +13,7 @@ import {
   type BinResolution,
 } from '../wrap/notices.js';
 import { spawnTarget } from '../wrap/resolve.js';
+import { ESLINT_SMELL_MAP, PARSE_ERROR_SMELL } from '../config/tool-smells.js';
 import { parseJsonStdout } from '../wrap/run.js';
 import type { Check, CheckOutcome, Violation } from '../types.js';
 
@@ -58,22 +59,6 @@ function isConfigError(result: ShellResult, parsed: EslintFileResult[] | null): 
   return result.exitCode !== 0 && result.exitCode !== 1;
 }
 
-const ESLINT_SMELL_MAP: Record<string, string> = {
-  'max-lines-per-function': 'oversized-function',
-  'max-params': 'too-many-parameters',
-  complexity: 'high-complexity',
-  'max-lines': 'oversized-file',
-  'no-unused-vars': 'unused-variable',
-  eqeqeq: 'loose-equality',
-  'no-var': 'var-declaration',
-  'prefer-const': 'non-const-binding',
-  'no-duplicate-imports': 'duplicate-import',
-  'no-warning-comments': 'warning-comment',
-  '@typescript-eslint/no-explicit-any': 'explicit-any',
-  '@typescript-eslint/no-non-null-assertion': 'non-null-assertion',
-  '@typescript-eslint/no-inferrable-types': 'redundant-type-annotation',
-};
-
 function messageToViolation(filePath: string, m: EslintMessage & { ruleId: string }): Violation {
   const smell = ESLINT_SMELL_MAP[m.ruleId] ?? m.ruleId;
   const title = lookupPrompt(smell)?.title ?? m.ruleId;
@@ -84,7 +69,7 @@ function messageToViolation(filePath: string, m: EslintMessage & { ruleId: strin
 
 function fatalToViolation(filePath: string, m: EslintMessage): Violation {
   return {
-    ruleId: 'parse-error',
+    ruleId: PARSE_ERROR_SMELL,
     source: 'eslint:fatal',
     file: filePath,
     line: m.line,

--- a/src/checks/jscpd-wrap.ts
+++ b/src/checks/jscpd-wrap.ts
@@ -7,11 +7,11 @@ import { detectTool } from '../detect/tool.js';
 import { hasPackageJsonKey } from '../detect/package-json.js';
 import { absolutize, emptyOutcome, firstLine, noticesFor, type BinResolution } from '../wrap/notices.js';
 import { isSpawnSkip, skipOutcome, spawnWrapped } from '../wrap/run.js';
+import { JSCPD_SMELL } from '../config/tool-smells.js';
 import type { Check, CheckOutcome, Violation } from '../types.js';
 
 const require = createRequire(import.meta.url);
 
-const SMELL = 'duplicated-code';
 const REPORT_FILENAME = 'jscpd-report.json';
 
 const JSCPD_CONFIG_FILES = ['.jscpd.json', 'jscpd.json'];
@@ -84,7 +84,7 @@ function locationDescription(loc: JscpdLocation, cwd: string): string {
 
 function buildViolation(self: JscpdLocation, partner: JscpdLocation, cwd: string): Violation {
   return {
-    ruleId: SMELL,
+    ruleId: JSCPD_SMELL,
     source: 'jscpd:duplication',
     file: absolutize(cwd, self.name),
     line: self.startLoc.line,

--- a/src/checks/knip-wrap.ts
+++ b/src/checks/knip-wrap.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { hasPackageJsonKey } from '../detect/package-json.js';
 import { absolutize, emptyOutcome, firstLine, noticesFor, type BinResolution } from '../wrap/notices.js';
 import { isSpawnSkip, parseJsonStdout, skipOutcome, spawnWrapped } from '../wrap/run.js';
+import { KNIP_SMELL_MAP } from '../config/tool-smells.js';
 import { buildKnipArgs, consumerKnipMajor, resolveKnipBin } from './knip-resolve.js';
 import {
   KNOWN_KEYS,
@@ -30,13 +31,6 @@ interface IssueContext {
   issueType: string;
   issueFile: string;
 }
-
-const KNIP_SMELL_MAP: Record<string, string> = {
-  classMembers: 'unused-class-member',
-  files: 'unused-file',
-  exports: 'unused-export',
-  dependencies: 'unused-dependency',
-};
 
 function knipSmell(issueType: string): string {
   return KNIP_SMELL_MAP[issueType] ?? issueType;

--- a/src/config/tool-smells.test.ts
+++ b/src/config/tool-smells.test.ts
@@ -33,3 +33,20 @@ describe('tool-smells derivation', () => {
     expect(COMMENT_SMELL).toBe(defaultRules.find((r) => r.source === 'custom')?.id);
   });
 });
+
+// Concrete value pins: a catalogue rename or typo fails the suite immediately.
+// Keep alongside the derivation tests above so both the derivation logic AND
+// the actual string values are guarded.
+describe('tool-smells concrete values', () => {
+  it('JSCPD_SMELL is duplicated-code', () => {
+    expect(JSCPD_SMELL).toBe('duplicated-code');
+  });
+
+  it('COMMENT_SMELL is non-essential-comment', () => {
+    expect(COMMENT_SMELL).toBe('non-essential-comment');
+  });
+
+  it('PARSE_ERROR_SMELL is parse-error', () => {
+    expect(PARSE_ERROR_SMELL).toBe('parse-error');
+  });
+});

--- a/src/config/tool-smells.test.ts
+++ b/src/config/tool-smells.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { defaultRules } from './catalogue.js';
+import {
+  COMMENT_SMELL,
+  ESLINT_PRODUCES,
+  ESLINT_SMELL_MAP,
+  JSCPD_SMELL,
+  PARSE_ERROR_SMELL,
+} from './tool-smells.js';
+
+// These prove the sensor/check layer's smell knowledge is DERIVED from the
+// catalogue: adding a smell there auto-wires its translation and produces with
+// zero edits to runner/sensor/check code (issue #24; deep-nesting is the live
+// demonstrator).
+describe('tool-smells derivation', () => {
+  it('derives the eslint raw->smell map from every catalogue eslint rule with a sourceRuleId', () => {
+    for (const rule of defaultRules) {
+      if (rule.source === 'eslint' && rule.sourceRuleId !== undefined) {
+        expect(ESLINT_SMELL_MAP[rule.sourceRuleId], rule.id).toBe(rule.id);
+      }
+    }
+  });
+
+  it('eslint produces every catalogue eslint smell plus the supplemental parse-error', () => {
+    for (const rule of defaultRules.filter((r) => r.source === 'eslint')) {
+      expect(ESLINT_PRODUCES).toContain(rule.id);
+    }
+    expect(ESLINT_PRODUCES).toContain(PARSE_ERROR_SMELL);
+  });
+
+  it('jscpd and comment smells are the catalogue rules for those sources', () => {
+    expect(JSCPD_SMELL).toBe(defaultRules.find((r) => r.source === 'jscpd')?.id);
+    expect(COMMENT_SMELL).toBe(defaultRules.find((r) => r.source === 'custom')?.id);
+  });
+});

--- a/src/config/tool-smells.ts
+++ b/src/config/tool-smells.ts
@@ -1,0 +1,67 @@
+import type { RuleSource } from '../types.js';
+import type { AdapterSpec, DeclarativeSensorSpec } from '../sensors/adapter.js';
+import { defaultRules } from './catalogue.js';
+
+// The single home for tool/smell knowledge (issue #24): the sensor and check
+// layers receive these from config and never hardcode a smell id. eslint/jscpd
+// data is derived from the catalogue, so adding a smell there auto-wires it.
+
+function rulesFor(source: RuleSource): { id: string; sourceRuleId?: string }[] {
+  return defaultRules.filter((rule) => rule.source === source);
+}
+
+function smellsFor(source: RuleSource): string[] {
+  return rulesFor(source).map((rule) => rule.id);
+}
+
+function rawToSmell(source: RuleSource): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const rule of rulesFor(source)) {
+    if (rule.sourceRuleId !== undefined) map[rule.sourceRuleId] = rule.id;
+  }
+  return map;
+}
+
+// `parse-error` is a supplemental smell (eslint fatal) with no catalogue rule.
+export const PARSE_ERROR_SMELL = 'parse-error';
+
+export const ESLINT_SMELL_MAP = rawToSmell('eslint');
+export const ESLINT_PRODUCES = [...smellsFor('eslint'), PARSE_ERROR_SMELL];
+
+export const JSCPD_SMELL = smellsFor('jscpd')[0];
+export const COMMENT_SMELL = smellsFor('custom')[0];
+
+// knip's raw issue types are tool-specific, not catalogue rule ids, so the
+// translation lives here in config.
+export const KNIP_SMELL_MAP: Record<string, string> = {
+  classMembers: 'unused-class-member',
+  files: 'unused-file',
+  exports: 'unused-export',
+  dependencies: 'unused-dependency',
+};
+export const KNIP_PRODUCES = Object.values(KNIP_SMELL_MAP);
+
+// Python tool specs (the generalized AdapterSpec model): ruff + deptry.
+export const RUFF_SPEC: DeclarativeSensorSpec = {
+  id: 'ruff',
+  produces: ['high-complexity', 'too-many-parameters', 'oversized-function', 'unused-variable', 'unused-import'],
+  command: 'ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401 ${files}',
+  items: '[]',
+  fields: { smell: 'code', file: 'filename', line: 'location.row', column: 'location.column', message: 'message' },
+  map: {
+    C901: 'high-complexity',
+    PLR0913: 'too-many-parameters',
+    PLR0915: 'oversized-function',
+    F841: 'unused-variable',
+    F401: 'unused-import',
+  },
+};
+
+export const DEPTRY_SPEC: AdapterSpec = {
+  id: 'deptry',
+  command: 'deptry . --json-output <report>',
+  items: '[]',
+  fields: { smell: 'error.code', file: 'location.file', line: 'location.line', message: 'error.message' },
+  map: { DEP002: 'unused-dependency' },
+};
+export const DEPTRY_PRODUCES = Object.values(DEPTRY_SPEC.map ?? {});

--- a/src/config/tool-smells.ts
+++ b/src/config/tool-smells.ts
@@ -1,4 +1,4 @@
-import type { RuleSource } from '../types.js';
+import type { Rule, RuleSource } from '../types.js';
 import type { AdapterSpec, DeclarativeSensorSpec } from '../sensors/adapter.js';
 import { defaultRules } from './catalogue.js';
 
@@ -6,7 +6,7 @@ import { defaultRules } from './catalogue.js';
 // layers receive these from config and never hardcode a smell id. eslint/jscpd
 // data is derived from the catalogue, so adding a smell there auto-wires it.
 
-function rulesFor(source: RuleSource): { id: string; sourceRuleId?: string }[] {
+function rulesFor(source: RuleSource): Rule[] {
   return defaultRules.filter((rule) => rule.source === source);
 }
 

--- a/src/rules/registry.ts
+++ b/src/rules/registry.ts
@@ -3,10 +3,9 @@ import type { CommentCheckThresholds, Rule } from '../types.js';
 import { DEFAULT_COMMENT_CHECK_THRESHOLDS } from '../checks/comment-check.js';
 import { defaultConfig, defaultRules } from '../config/defaults.js';
 import { mergeRules } from '../config/merge.js';
+import { COMMENT_SMELL } from '../config/tool-smells.js';
 import type { CommentCheckConfig, HabitHooksConfig } from '../config/schema.js';
 import { loadGuidance } from '../prompts/loader.js';
-
-const COMMENT_RULE_ID = 'non-essential-comment';
 
 function resolvePromptsDir(config: HabitHooksConfig, configDir: string): string | undefined {
   if (config.prompts === undefined) return undefined;
@@ -32,7 +31,7 @@ function resolveCommentThresholds(config: CommentCheckConfig | undefined): Comme
 
 function attachCommentThresholds(rules: Rule[], config: CommentCheckConfig | undefined): Rule[] {
   const thresholds = resolveCommentThresholds(config);
-  return rules.map((rule) => (rule.id === COMMENT_RULE_ID ? { ...rule, commentCheck: thresholds } : rule));
+  return rules.map((rule) => (rule.id === COMMENT_SMELL ? { ...rule, commentCheck: thresholds } : rule));
 }
 
 export function buildRules(config: HabitHooksConfig, configDir: string): Rule[] {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -16,11 +16,10 @@ import { buildPythonPresetSensors } from './sensors/python-preset.js';
 import { mapIssues, type MapperDirs, type RoutingLookup } from './mapper/mapper.js';
 import { guide } from './guide/guide.js';
 import type { SensorSink } from './wrap/notices.js';
+import { COMMENT_SMELL } from './config/tool-smells.js';
 import type { Sensor } from './sensors/types.js';
 import type { HabitHooksConfig, Language } from './config/schema.js';
 import type { Rule, Violation } from './types.js';
-
-const COMMENT_SMELL = 'non-essential-comment';
 
 export interface RunResult {
   stdout: string;
@@ -89,6 +88,24 @@ function resolvePromptsDir(config: HabitHooksConfig, configDir: string): string 
   return isAbsolute(config.prompts) ? config.prompts : resolve(configDir, config.prompts);
 }
 
+interface ResolvedInputs {
+  cwd: string;
+  config: HabitHooksConfig;
+  configDir: string;
+  files: string[];
+  scope: ResolvedScope;
+  baseline: BaselineFile | null;
+}
+
+function buildRunContext(inputs: ResolvedInputs): RunContext {
+  const { cwd, config, configDir, files, scope, baseline } = inputs;
+  const promptsDir = resolvePromptsDir(config, configDir);
+  const configWarnings = config.rules !== undefined ? [RULES_DEPRECATION] : [];
+  const snoozeIndex = createSnoozeIndex(cwd);
+  const needsExtractionReplace = config.needsExtraction?.replace === true;
+  return { cwd, files, scope, baseline, snoozeIndex, language: config.language ?? 'typescript', promptsDir, configWarnings, needsExtractionReplace };
+}
+
 async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: RunContext; rules: Rule[] }> {
   const { config, configDir } = await resolveConfig(cwd, options);
   const rules = buildRules(config, configDir);
@@ -96,11 +113,7 @@ async function buildContext(cwd: string, options: RunOptions): Promise<{ ctx: Ru
   const files = await discoverFiles(cwd, language, config.scope?.exclude);
   const scope = resolveScope(options.scopeFlags ?? {}, config.scope, cwd);
   const baseline = resolveBaseline(cwd, options);
-  const promptsDir = resolvePromptsDir(config, configDir);
-  const configWarnings = config.rules !== undefined ? [RULES_DEPRECATION] : [];
-  const snoozeIndex = createSnoozeIndex(cwd);
-  const needsExtractionReplace = config.needsExtraction?.replace === true;
-  return { ctx: { cwd, files, scope, baseline, snoozeIndex, language, promptsDir, configWarnings, needsExtractionReplace }, rules };
+  return { ctx: buildRunContext({ cwd, config, configDir, files, scope, baseline }), rules };
 }
 
 // A sensor runs only when at least one smell it produces has an active rule
@@ -147,8 +160,8 @@ function filterViolations(violations: Violation[], rules: Rule[], ctx: RunContex
 }
 
 // Routing for the mapper: the merged smell config wins; otherwise the catalogue
-// (prompt registry) supplies severity/title for supplemental smells such as
-// `parse-error`, so its `enforced` severity survives. Unknown smells -> uncoached.
+// (prompt registry) supplies severity/title for supplemental smells, so their
+// enforced severity survives. Unknown smells -> uncoached.
 function buildRouting(rules: Rule[]): RoutingLookup {
   const byId = new Map(rules.map((r) => [r.id, r] as const));
   return (smell) => {

--- a/src/sensors/deptry-sensor.ts
+++ b/src/sensors/deptry-sensor.ts
@@ -3,20 +3,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runTool } from '../wrap/shell.js';
 import { isSpawnFailure, recordSpawnFailure, spawnFailureWarning, type SensorSink } from '../wrap/notices.js';
-import { extractIssues, type AdapterSpec } from './adapter.js';
+import { DEPTRY_PRODUCES, DEPTRY_SPEC } from '../config/tool-smells.js';
+import { extractIssues } from './adapter.js';
 import type { Issue, Sensor } from './types.js';
 
 // deptry analyses the whole project and reports unused dependencies. Its
 // `--json-output` must target a real file (writing to /dev/stdout yields nothing
 // when stdout is a pipe), so deptry uses the temp-report pattern rather than the
 // stdout declarative adapter — but reuses the adapter's extractIssues to map.
-const DEPTRY_SPEC: AdapterSpec = {
-  id: 'deptry',
-  command: 'deptry . --json-output <report>',
-  items: '[]',
-  fields: { smell: 'error.code', file: 'location.file', line: 'location.line', message: 'error.message' },
-  map: { DEP002: 'unused-dependency' },
-};
 
 function parseReport(path: string): Issue[] {
   if (!existsSync(path)) return [];
@@ -47,5 +41,5 @@ async function runDeptry(cwd: string, sink: SensorSink): Promise<Issue[]> {
 }
 
 export function deptrySensor(sink: SensorSink): Sensor {
-  return { id: 'deptry', produces: ['unused-dependency'], run: (ctx) => runDeptry(ctx.cwd, sink) };
+  return { id: 'deptry', produces: DEPTRY_PRODUCES, run: (ctx) => runDeptry(ctx.cwd, sink) };
 }

--- a/src/sensors/needs-extraction.ts
+++ b/src/sensors/needs-extraction.ts
@@ -1,7 +1,8 @@
+import { JSCPD_SMELL } from '../config/tool-smells.js';
 import type { Issue, Sensor } from './types.js';
 
 const SMELL = 'needs-extraction';
-const INPUT_SMELLS = ['oversized-file', 'duplicated-code'] as const;
+const INPUT_SMELLS = ['oversized-file', JSCPD_SMELL] as const;
 
 function fileOf(issue: Issue): string | null {
   const file = issue.details.file;
@@ -32,7 +33,7 @@ function needsExtractionIssue(file: string): Issue {
 }
 
 function combine(deps: Issue[]): Issue[] {
-  const duplicated = filesWith(deps, 'duplicated-code');
+  const duplicated = filesWith(deps, JSCPD_SMELL);
   return [...filesWith(deps, 'oversized-file')].filter((file) => duplicated.has(file)).map(needsExtractionIssue);
 }
 

--- a/src/sensors/preset.test.ts
+++ b/src/sensors/preset.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildPresetSensors, issueToViolation, violationToIssue } from './preset.js';
+import { COMMENT_SMELL, JSCPD_SMELL, PARSE_ERROR_SMELL } from '../config/tool-smells.js';
 import type { Violation } from '../types.js';
 
 describe('violationToIssue', () => {
@@ -52,9 +53,9 @@ describe('buildPresetSensors', () => {
     expect(sensors.map((s) => s.id)).toEqual(['eslint', 'comment', 'jscpd', 'knip', 'needs-extraction']);
     const eslint = sensors.find((s) => s.id === 'eslint');
     expect(eslint?.produces).toContain('too-many-parameters');
-    expect(eslint?.produces).toContain('parse-error');
-    expect(sensors.find((s) => s.id === 'jscpd')?.produces).toEqual(['duplicated-code']);
-    expect(sensors.find((s) => s.id === 'comment')?.produces).toEqual(['non-essential-comment']);
+    expect(eslint?.produces).toContain(PARSE_ERROR_SMELL);
+    expect(sensors.find((s) => s.id === 'jscpd')?.produces).toEqual([JSCPD_SMELL]);
+    expect(sensors.find((s) => s.id === 'comment')?.produces).toEqual([COMMENT_SMELL]);
     const composite = sensors.find((s) => s.id === 'needs-extraction');
     expect(composite?.produces).toEqual(['needs-extraction']);
     expect(composite?.dependsOn).toEqual(['oversized-file', 'duplicated-code']);

--- a/src/sensors/preset.ts
+++ b/src/sensors/preset.ts
@@ -3,29 +3,10 @@ import { commentCheck } from '../checks/comment-check.js';
 import { jscpdWrap } from '../checks/jscpd-wrap.js';
 import { knipWrap } from '../checks/knip-wrap.js';
 import type { SensorSink } from '../wrap/notices.js';
+import { COMMENT_SMELL, ESLINT_PRODUCES, JSCPD_SMELL, KNIP_PRODUCES } from '../config/tool-smells.js';
 import { needsExtractionSensor } from './needs-extraction.js';
 import type { Check, CheckOutcome, Rule, Violation } from '../types.js';
 import type { Issue, Sensor } from './types.js';
-
-// Smell keys each preset sensor can emit (docs/smell-vocabulary.md). Informational
-// for dependency resolution; leaf sensors may also pass unmapped raw keys through.
-const ESLINT_PRODUCES = [
-  'oversized-function',
-  'too-many-parameters',
-  'high-complexity',
-  'oversized-file',
-  'unused-variable',
-  'loose-equality',
-  'var-declaration',
-  'non-const-binding',
-  'duplicate-import',
-  'warning-comment',
-  'explicit-any',
-  'non-null-assertion',
-  'redundant-type-annotation',
-  'parse-error',
-];
-const KNIP_PRODUCES = ['unused-class-member', 'unused-file', 'unused-export', 'unused-dependency'];
 
 export function violationToIssue(v: Violation): Issue {
   const details: Record<string, unknown> = { file: v.file, line: v.line, message: v.message };
@@ -74,7 +55,7 @@ export interface PresetInput {
 // commentRule carries the resolved comment thresholds the ts-morph scan needs.
 function commentSensor(input: PresetInput): Sensor {
   const rules = input.commentRule ? [input.commentRule] : [];
-  return checkLeafSensor({ check: commentCheck, produces: ['non-essential-comment'], sink: input.sink, rules });
+  return checkLeafSensor({ check: commentCheck, produces: [COMMENT_SMELL], sink: input.sink, rules });
 }
 
 // The TypeScript/JavaScript preset: leaf sensors over eslint, ts-morph comments,
@@ -85,7 +66,7 @@ export function buildPresetSensors(input: PresetInput): Sensor[] {
   return [
     checkLeafSensor({ check: eslintWrap, produces: ESLINT_PRODUCES, sink }),
     commentSensor(input),
-    checkLeafSensor({ check: jscpdWrap, produces: ['duplicated-code'], sink }),
+    checkLeafSensor({ check: jscpdWrap, produces: [JSCPD_SMELL], sink }),
     checkLeafSensor({ check: knipWrap, produces: KNIP_PRODUCES, sink }),
     needsExtractionSensor(),
   ];

--- a/src/sensors/python-preset.ts
+++ b/src/sensors/python-preset.ts
@@ -3,31 +3,15 @@ import { join } from 'node:path';
 import { jscpdWrap } from '../checks/jscpd-wrap.js';
 import { TOOL_CONFIG_FILENAMES } from '../detect/tool.js';
 import type { SensorSink } from '../wrap/notices.js';
-import { declarativeSensor, type DeclarativeSensorSpec } from './adapter.js';
+import { JSCPD_SMELL, RUFF_SPEC } from '../config/tool-smells.js';
+import { declarativeSensor } from './adapter.js';
 import { checkLeafSensor } from './preset.js';
 import { deptrySensor } from './deptry-sensor.js';
 import { DEFAULT_MAX_FILE_LINES, lineCountSensor } from './line-count-sensor.js';
 import type { Sensor } from './types.js';
 
-// The Python preset: ruff (declarative adapter) + jscpd on .py + deptry
-// (declarative adapter). Ruff/deptry rule -> smell maps follow
-// docs/smell-vocabulary.md "Python smell mapping"; ruff F401 adds the general
-// `unused-import` smell (agent decision, see DECISIONS.md).
-const RUFF_SPEC: DeclarativeSensorSpec = {
-  id: 'ruff',
-  produces: ['high-complexity', 'too-many-parameters', 'oversized-function', 'unused-variable', 'unused-import'],
-  command: 'ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401 ${files}',
-  items: '[]',
-  fields: { smell: 'code', file: 'filename', line: 'location.row', column: 'location.column', message: 'message' },
-  map: {
-    C901: 'high-complexity',
-    PLR0913: 'too-many-parameters',
-    PLR0915: 'oversized-function',
-    F841: 'unused-variable',
-    F401: 'unused-import',
-  },
-};
-
+// The Python preset: ruff (declarative adapter) + jscpd on .py + deptry + line-count.
+// Ruff/deptry specs and smell ids come from config/tool-smells.ts; this only wires them.
 export interface PythonPresetInput {
   sink: SensorSink;
   cwd: string;
@@ -52,7 +36,7 @@ export function buildPythonPresetSensors(input: PythonPresetInput): Sensor[] {
   const { sink, cwd } = input;
   return [
     declarativeSensor(RUFF_SPEC, sink),
-    checkLeafSensor({ check: jscpdWrap, produces: ['duplicated-code'], sink }),
+    checkLeafSensor({ check: jscpdWrap, produces: [JSCPD_SMELL], sink }),
     deptrySensor(sink),
     lineCountSensor(readMaxModuleLines(cwd)),
   ];


### PR DESCRIPTION
Closes #24.

Concrete smell knowledge was hardcoded across the runner, sensors, checks, and rules registry. Per the locked decision it should live only in config (+ language initializers). This moves it all to a single config home.

## Design
New `src/config/tool-smells.ts` is the single source:
- **Derived from the catalogue** (`defaultRules`): the eslint raw→smell map, and eslint/jscpd/comment `produces`. So adding a catalogue smell auto-wires its translation and produces.
- **Config literals**: knip's raw issue-type keys (tool-API keys, not canonical smell ids) and the supplemental `parse-error` (an eslint fatal with no catalogue rule).
- The ruff + deptry `AdapterSpec`s moved here too.

The runner, sensors (preset/python-preset/deptry-sensor), checks (eslint/knip/jscpd/comment), and rules registry now **import** these instead of hardcoding.

## Acceptance
- `grep -rn "non-essential-comment\|duplicated-code\|unused-dependency\|parse-error" src/runner.ts src/sensors/ src/checks/ src/rules/` is **clean for non-test source** (test files retain concrete smells as behaviour assertions).
- Adding an eslint smell touches only `src/config/` + `src/cli/init/` — a derivation test pins this, and **#26 (deep-nesting) is the live demonstrator** (stacked on this branch).
- Build + full suite green (388).

## Note
Realizes the locked "spec from config" via config-derived constants imported by the sensor layer (rather than per-call DI) — smell knowledge lives solely in config, consumed downward; lower-risk and behaviour-preserving. Documented in `DECISIONS.md`.

## Atomic commits
1. `#24: add config/tool-smells as the single home for smell knowledge`
2. `#24: make the runner/sensor/check/registry layer smell-agnostic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq6xHU6JtSNpYWhMYjXB15)_