### PR TITLE
Add ruff BLE001 as a swallowed-exception smell

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -164,6 +164,15 @@ Each is labelled _agent decision_ per the working agreement.
   `oversized-file` for Python** — no clean ruff rule (GOAL says best-effort or
   defer). deptry's `/dev/stdout` JSON is POSIX-only, fine for the Linux e2e.
 
+- **Added ruff `BLE001` -> `swallowed-exception` (new smell).** A broad `except`
+  that catches and discards the error is a silent-failure risk and has no clean
+  TypeScript twin, so `swallowed-exception` is the first catalogue smell to carry
+  `source: 'ruff'` (added to `RuleSource` in `types.ts` and to config validation,
+  mirroring how `knip` is a spec-driven source). Severity `suggested`: blind-except
+  has legitimate top-level uses (a request handler, a worker loop), so it coaches
+  rather than failing the run. Exercised only when ruff is on PATH, skipped on CI
+  like the other Python sensors.
+
 - The live-ruff preset test skips when ruff is not on PATH (CI without the Python
   toolchain) so the suite stays green everywhere; it runs in the provisioned env.
 

--- a/docs/smell-vocabulary.md
+++ b/docs/smell-vocabulary.md
@@ -45,10 +45,14 @@ exits 0. The mapper config can override it per project.
 | `unused-export`             | Unused export                         | enforced         |
 | `unused-dependency`         | Unused dependency                     | enforced         |
 | `unused-import`             | Unused import                         | enforced         |
+| `swallowed-exception`       | Swallowed exception                   | suggested        |
 | `parse-error`               | Parse / config error                  | enforced         |
 
 `unused-import` was added as a general smell (agent decision) so ruff `F401`
 has a canonical home; see `DECISIONS.md`.
+
+`swallowed-exception` is the first smell sourced only from ruff (`BLE001`), with
+no TypeScript twin; it carries `source: 'ruff'`. See `DECISIONS.md`.
 
 ## TypeScript/JavaScript preset translation
 
@@ -91,6 +95,7 @@ to (the rest of the catalogue is shared — only the sensor layer differs).
 | `ruff:PLR0915`      | `oversized-function`  |
 | `ruff:F841`         | `unused-variable`     |
 | `ruff:F401`         | `unused-import`       |
+| `ruff:BLE001`       | `swallowed-exception` |
 | `jscpd:duplication` | `duplicated-code`     |
 | `deptry:DEP002`     | `unused-dependency`   |
 | `line-count:max-module-lines` | `oversized-file` |

--- a/src/config/catalogue.ts
+++ b/src/config/catalogue.ts
@@ -160,11 +160,24 @@ const jscpdRules: Rule[] = [
   },
 ];
 
+// ruff-only smells: no TypeScript-tool twin, so they carry source 'ruff'.
+const ruffRules: Rule[] = [
+  {
+    id: 'swallowed-exception',
+    source: 'ruff',
+    severity: 'suggested',
+    changedFilesOnly: true,
+    title: 'Swallowed exception',
+    description: 'A broad except that catches and discards the error hides failures; catch the specific exception and handle or re-raise it.',
+  },
+];
+
 export const defaultRules: Rule[] = [
   ...tier1Rules,
   ...tier2Rules,
   ...tier3Rules,
   ...customRules,
   ...jscpdRules,
+  ...ruffRules,
   ...unusedRules,
 ];

--- a/src/config/tool-smells.ts
+++ b/src/config/tool-smells.ts
@@ -58,8 +58,8 @@ export const KNIP_PRODUCES = Object.values(KNIP_SMELL_MAP);
 // Python tool specs (the generalized AdapterSpec model): ruff + deptry.
 export const RUFF_SPEC: DeclarativeSensorSpec = {
   id: 'ruff',
-  produces: ['high-complexity', 'too-many-parameters', 'oversized-function', 'unused-variable', 'unused-import'],
-  command: 'ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401 ${files}',
+  produces: ['high-complexity', 'too-many-parameters', 'oversized-function', 'unused-variable', 'unused-import', 'swallowed-exception'],
+  command: 'ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401,BLE001 ${files}',
   items: '[]',
   fields: { smell: 'code', file: 'filename', line: 'location.row', column: 'location.column', message: 'message' },
   map: {
@@ -68,6 +68,7 @@ export const RUFF_SPEC: DeclarativeSensorSpec = {
     PLR0915: 'oversized-function',
     F841: 'unused-variable',
     F401: 'unused-import',
+    BLE001: 'swallowed-exception',
   },
 };
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -16,7 +16,7 @@ import {
 import { validateFiles, validateSensors } from './validate-sensors.js';
 
 const SEVERITIES: readonly Severity[] = ['enforced', 'suggested'];
-const SOURCES: readonly RuleSource[] = ['eslint', 'jscpd', 'knip', 'custom'];
+const SOURCES: readonly RuleSource[] = ['eslint', 'jscpd', 'knip', 'ruff', 'custom'];
 
 function validateOptionalBoolean(value: unknown, path: string): void {
   if (value === undefined) return;
@@ -32,7 +32,7 @@ function validateSeverity(value: unknown, path: string): void {
 
 function validateSource(value: unknown, path: string): void {
   if (typeof value !== 'string' || !SOURCES.includes(value as RuleSource)) {
-    fail(path, `one of 'eslint', 'jscpd', 'knip', 'custom'`);
+    fail(path, `one of 'eslint', 'jscpd', 'knip', 'ruff', 'custom'`);
   }
 }
 

--- a/src/prompts/swallowed-exception.md
+++ b/src/prompts/swallowed-exception.md
@@ -1,0 +1,9 @@
+A broad `except` (`except:`, `except Exception`, `except BaseException`) that swallows the error is hiding a failure you have not understood, not handling one you planned for. Before writing it, name the specific error you expect here and why. That sentence is usually the fix.
+
+Catch only the exception you actually expect: `ValueError`, `KeyError`, `TimeoutError`, whatever the call can really raise. If you cannot name it, you are guessing, and every other error should stay free to surface where it can be seen.
+
+Then do something real: recover, or add context and re-raise (`raise ... from err`), or let it propagate. Catching broadly and then `pass`, logging-and-continuing, or returning a default is the swallow. The bug does not disappear. It resurfaces later, far from here, where it costs the most.
+
+Narrowing the type or adding `# noqa` only to quiet the checker is not a fix if the error is still discarded. The smell is the silent swallow, not the width of the catch.
+
+One legitimate case: a top-level boundary that must stay alive (a request handler, a worker loop, a CLI entry point). Even there, catch as narrow as you can, log the full traceback, and never discard the error silently. If unsure, check with a human first.

--- a/src/python-acceptance.test.ts
+++ b/src/python-acceptance.test.ts
@@ -13,6 +13,7 @@ const pythonProject = join(here, '..', 'tests', 'fixtures', 'python-project');
 // toolchain is absent (CI without it) so the suite stays green everywhere.
 const PY_TOOLS =
   spawnSync('ruff', ['--version']).status === 0 && spawnSync('deptry', ['--version']).status === 0;
+const RUFF = spawnSync('ruff', ['--version']).status === 0;
 
 interface ExpectedCount {
   ruleId: string;
@@ -133,5 +134,38 @@ describe('python needs-extraction (composite sensor)', () => {
     expect(violations.filter((v) => v.ruleId === 'needs-extraction').length).toBeGreaterThan(0);
     expect(violations.filter((v) => v.ruleId === 'oversized-file')).toEqual([]);
     expect(violations.filter((v) => v.ruleId === 'duplicated-code')).toEqual([]);
+  }, 30_000);
+});
+
+// ruff BLE001 -> swallowed-exception. Needs only ruff on PATH (no deptry), so it
+// gates on RUFF alone and asserts on violations, not exit code.
+describe.skipIf(!RUFF)('python swallowed-exception (ruff BLE001)', () => {
+  let dir = '';
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = '';
+  });
+
+  function pythonFile(body: string): void {
+    dir = mkdtempSync(join(tmpdir(), 'hh-py-swallowed-'));
+    writeFileSync(join(dir, 'habit-hooks.config.json'), JSON.stringify({ language: 'python' }));
+    writeFileSync(join(dir, 'risky.py'), body);
+  }
+
+  it('fires for a broad except that swallows the error', async () => {
+    pythonFile('def risky(x):\n    try:\n        return int(x)\n    except Exception:\n        return None\n');
+
+    const result = await run(dir);
+
+    expect(result.violations.some((v) => v.ruleId === 'swallowed-exception')).toBe(true);
+  }, 30_000);
+
+  it('does not fire for a specific, named except', async () => {
+    pythonFile('def risky(x):\n    try:\n        return int(x)\n    except ValueError:\n        return None\n');
+
+    const result = await run(dir);
+
+    expect(result.violations.some((v) => v.ruleId === 'swallowed-exception')).toBe(false);
   }, 30_000);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type Severity = 'enforced' | 'suggested';
-export type RuleSource = 'eslint' | 'jscpd' | 'knip' | 'custom';
+export type RuleSource = 'eslint' | 'jscpd' | 'knip' | 'ruff' | 'custom';
 
 export interface CommentCheckThresholds {
   maxSingleLineChars: number;


### PR DESCRIPTION
## What

Adds ruff's `BLE001` (blind-except) as a new `swallowed-exception` smell, with a coaching prompt that tells the agent what to do instead of just reporting the rule.

## Why

A broad `except` that swallows the error is a silent-failure risk. ruff already flags it; this turns the bare "Do not catch blind exception" into actionable guidance, in the habit-hooks style.

## Design note

`swallowed-exception` is the first smell sourced only from ruff, with no TypeScript twin (the existing ruff smells reuse an eslint or knip smell). So `Rule.source` needed a new value. I added `'ruff'` to `RuleSource` and to config validation, mirroring how `knip` is a spec-driven source. Happy to take a different approach if you'd prefer.

Severity is `suggested`, not `enforced`: blind-except has legitimate top-level uses (request handlers, worker loops), so it coaches rather than failing the run. Easy to flip.

## Changes

- `src/config/tool-smells.ts` (RUFF_SPEC): add `BLE001` to `--select`, `produces`, and the map.
- `src/config/catalogue.ts`: new `swallowed-exception` rule (`source: 'ruff'`).
- `src/types.ts` and `src/config/validate.ts`: add the `'ruff'` source.
- `src/prompts/swallowed-exception.md`: the coaching prompt.
- `docs/smell-vocabulary.md` and `docs/DECISIONS.md`: catalogue row, ruff mapping row, decision record.
- `src/python-acceptance.test.ts`: a test that `BLE001` fires `swallowed-exception` and that a specific, named `except` does not. Gated on ruff like the other Python tests (skipped on CI without the toolchain).

## Testing

Full suite green locally with ruff and deptry installed (503 passed). typecheck and lint clean.
