### PR TITLE
Document that Python projects need ruff and deptry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ npm install --save-dev habit-hooks
 
 habit-hooks depends on `eslint`, `knip`, and `jscpd`, so installing it pulls those in as well — a fresh project gets every wrap target for free. If your project already has its own versions installed, habit-hooks detects and uses those instead and falls back to the bundled binaries only when none is present.
 
+For Python projects, habit-hooks also wraps `ruff` and `deptry`. These are Python tools rather than npm packages, so they are not pulled in with habit-hooks. Install them yourself (for example `pip install ruff deptry`) to run habit-hooks on Python code.
+
 ## Quick start
 
 ```sh


### PR DESCRIPTION
## What

Add a note to the Install section that Python projects need `ruff` and `deptry` installed.

## Why

The README only documents the JavaScript tools (eslint, knip, jscpd). It does not mention that habit-hooks also supports Python, or that the Python side needs ruff and deptry, which are not pulled in with habit-hooks. A first-time Python user has no signal they are needed.
