### PR TITLE
fix(python): map ruff syntax errors to parse-error instead of a null smell

### DIFF
--- a/docs/python-plugin.spec.md
+++ b/docs/python-plugin.spec.md
@@ -51,6 +51,38 @@ habit-sensors --all | jq -c 'sort_by(.smell)[] | {smell, language, key: (.issues
 {"smell":"unused-variable","language":"python","key":"billing.py","line":5,"source":"ruff:F841"}
 ```
 
+## ruff maps a syntax error to parse-error
+
+A file ruff cannot parse surfaces as `parse-error` (ruff reports it as
+`invalid-syntax`), not a null smell, so a broken file is still coached rather
+than silently mislabelled. This mirrors the TS plugin, where `eslint:fatal`
+maps to `parse-error`.
+
+📄.habit-hooks/config.toml
+```toml
+plugins = ["python"]
+
+[sensors.deptry]
+disabled = true
+```
+
+📄ruff.toml @plugins/python/src/habit_hooks_python/ruff.toml
+
+📄broken.py
+```python
+def broken(:
+    return 1
+```
+
+```bash
+habit-sensors --all | jq -c '.[] | {smell, source: .issues[0].details.source}'
+```
+
+🖥️ ✅
+```json
+{"smell":"parse-error","source":"ruff:invalid-syntax"}
+```
+
 ## deptry sensor maps DEP002 to unused-dependency
 
 The `deptry` sensor runs deptry against a temp JSON report and shapes each
@@ -173,7 +205,8 @@ ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401,BLE001 $
     "PLR0915": "oversized-function",
     "F841": "unused-variable",
     "F401": "unused-import",
-    "BLE001": "swallowed-exception"
+    "BLE001": "swallowed-exception",
+    "invalid-syntax": "parse-error"
   }[.code])})
   | group_by(.smell)
   | map({

--- a/docs/smell-vocabulary.md
+++ b/docs/smell-vocabulary.md
@@ -98,6 +98,7 @@ only the plugin's sensors differ).
 | `ruff:F841`         | `unused-variable`     |
 | `ruff:F401`         | `unused-import`       |
 | `ruff:BLE001`       | `swallowed-exception` |
+| `ruff:invalid-syntax` | `parse-error`       |
 | `jscpd:duplication` | `duplicated-code`     |
 | `deptry:DEP002`     | `unused-dependency`   |
 | `line-count:max-module-lines` | `oversized-file` |

--- a/plugins/python/src/habit_hooks_python/sensors/ruff.toml
+++ b/plugins/python/src/habit_hooks_python/sensors/ruff.toml
@@ -7,7 +7,8 @@ ruff check --output-format=json --select=C901,PLR0913,PLR0915,F841,F401,BLE001 $
     "PLR0915": "oversized-function",
     "F841": "unused-variable",
     "F401": "unused-import",
-    "BLE001": "swallowed-exception"
+    "BLE001": "swallowed-exception",
+    "invalid-syntax": "parse-error"
   }[.code])})
   | group_by(.smell)
   | map({


### PR DESCRIPTION
## The bug

A Python file that ruff cannot parse comes out with a null smell instead of `parse-error`. It renders as `── None ──`, so a broken file is surfaced but mislabelled, not coached as the parse error it is.

## Root cause

ruff reports syntax errors with the code `invalid-syntax`. The python ruff sensor's map only knows the six lint codes it selects, so `invalid-syntax` falls through the map to `null`.

The TypeScript plugin already handles this: `eslint:fatal` maps to `parse-error` (see `smell-vocabulary.md`). Python was just missing its twin, and the catalogue already has `parse-error` (enforced).

## The fix

Map `ruff:invalid-syntax` to `parse-error` in the python ruff sensor, so a broken file is coached as a parse error and matches the TS behaviour.

## Tests

- New case in `python-plugin.spec.md`: a syntax-error file comes out as `parse-error` from `ruff:invalid-syntax`.
- Updated the mirrored sensor command in the existing "crashing ruff" stderr assertion so it stays in lockstep.
- Added the matching row for `ruff:invalid-syntax` and `parse-error` in `smell-vocabulary.md`.

The Python suite is green. The Node and PHP sensor specs that fail in CI are pre-existing and unrelated to this change (the workflow installs Python only).
