### PR TITLE
feat(python): add an opinionated swallowed-exception guide

### DIFF
--- a/docs/habit-mapper.spec.md
+++ b/docs/habit-mapper.spec.md
@@ -408,6 +408,55 @@ habit-mapper
 biome: prefer `===`/`!==` over loose equality.
 ```
 
+### The python plugin ships an opinionated swallowed-exception guide
+
+`swallowed-exception` comes only from ruff (`BLE001`), so it is python-only. The
+python plugin ships its own guide for it, so a `["python"]` config coaches it
+directly with no `generic` present. The guide inlines its own line listing rather
+than the generic `includes/line_level_issues.md`, so it never depends on `generic`
+being installed. It is `suggested`, so it coaches but the run stays green.
+
+📄.habit-hooks/config.toml
+```toml
+plugins = ["python"]
+```
+
+⌨️
+```json
+[
+  {
+    "smell": "swallowed-exception",
+    "language": "python",
+    "details": {},
+    "issues": [
+      { "key": "src/loader.py:4", "details": { "file": "src/loader.py", "line": 4 } }
+    ]
+  }
+]
+```
+
+```bash
+habit-mapper
+```
+
+🖥️ ✅
+```text
+── swallowed-exception (1 issue) ──
+
+A broad `except` (`except:`, `except Exception`, `except BaseException`) that discards the error silently is hiding a failure you have not understood, not handling one you planned for. Before you write it, name the specific error you expect and why. That one sentence is usually the fix.
+
+src/loader.py:4
+Work through it in order:
+
+1. **Catch only what you can name.** `ValueError`, `KeyError`, `TimeoutError`, whatever the call really raises. If you cannot name it, you are guessing, and every other error should stay free to surface where someone can see it.
+2. **Make the decision visible.** Recover from it, add context and re-raise (`raise ... from err`), or, at a boundary that has to stay alive, log the full traceback (`logging.exception(...)`) and continue. Logging and returning a default is a real option, not automatically a swallow.
+3. **The test is not whether you re-raised.** Ask one question: if this fires at 3am, will anyone know it happened, and will they know why? What turns a catch into a swallow is doing it blindly: a wide catch, no named error, nothing logged, the failure gone without a trace. If the answer is no, it is still a swallow, however you dressed it up.
+
+Narrowing the type or adding `# noqa` only to quiet ruff is not a fix if the error is still discarded.
+
+If you are unsure whether this catch is a real decision or a reflex, check with a human before you keep it.
+```
+
 ### An unknown smell escalates with the default guidance
 
 A smell with no catalogue entry has no tuned guide. It defaults to `enforced`

--- a/plugins/python/src/habit_hooks_python/guides/swallowed-exception.md
+++ b/plugins/python/src/habit_hooks_python/guides/swallowed-exception.md
@@ -1,0 +1,14 @@
+A broad `except` (`except:`, `except Exception`, `except BaseException`) that discards the error silently is hiding a failure you have not understood, not handling one you planned for. Before you write it, name the specific error you expect and why. That one sentence is usually the fix.
+
+{% for issue in issues -%}
+{{ issue.details.file }}:{{ issue.details.line }}{% if issue.details.content %}  {{ issue.details.content }}{% endif %}
+{% endfor -%}
+Work through it in order:
+
+1. **Catch only what you can name.** `ValueError`, `KeyError`, `TimeoutError`, whatever the call really raises. If you cannot name it, you are guessing, and every other error should stay free to surface where someone can see it.
+2. **Make the decision visible.** Recover from it, add context and re-raise (`raise ... from err`), or, at a boundary that has to stay alive, log the full traceback (`logging.exception(...)`) and continue. Logging and returning a default is a real option, not automatically a swallow.
+3. **The test is not whether you re-raised.** Ask one question: if this fires at 3am, will anyone know it happened, and will they know why? What turns a catch into a swallow is doing it blindly: a wide catch, no named error, nothing logged, the failure gone without a trace. If the answer is no, it is still a swallow, however you dressed it up.
+
+Narrowing the type or adding `# noqa` only to quiet ruff is not a fix if the error is still discarded.
+
+If you are unsure whether this catch is a real decision or a reflex, check with a human before you keep it.


### PR DESCRIPTION
## What this adds

An opinionated Python guide for `swallowed-exception` (ruff `BLE001`), so a python config coaches the smell directly. Today a `["python"]` config has no guide for it and falls through to the generic default, or to uncoached when `generic` is not present.

## The coaching stance

It coaches the judgment instead of enforcing a blanket rule. Name the specific exception, narrow the catch to it, then make the decision visible. Logging and returning a default is treated as a real option, not automatically a swallow. The check it gives is behavioural: "if this fires at 3am, will anyone know it happened, and why." A swallow is the blind version, a wide catch, nothing named, nothing logged, no trace.

## Design notes

- The guide inlines its own line listing rather than `{% include "includes/line_level_issues.md" %}`. That include lives in the generic plugin, so a `["python"]` config with no generic would crash on it. Inlining keeps the guide self-contained and safe for python-only.
- It follows the shape of `deep-nesting.md`: a prose diagnosis, the line listing, a numbered procedure with bold lead-ins, then an anti-gaming closer.

## Tests

One new case in `habit-mapper.spec.md` renders the guide for a python-only swallowed-exception finding (suggested, exits 0). Full python suite green (+1 test, no regressions vs base). The Node and PHP specs that fail in CI are pre-existing and unrelated (the workflow installs Python only).

## Note on PR #68

This makes `swallowed-exception` guided for a python-only config. My other open PR (#68) uses `swallowed-exception` as its example of an unguided smell, in the case "A python-only config coaches an unguided smell via the core uncoached guide." If both land, that test should switch to another still-unguided python smell such as `too-many-parameters`. Flagging so the merge order is clear.

## Style

Kept the prose tight and dash-free for clarity, happy to match the house em-dash style if you would rather.
