### PR TITLE
feat(python): add an opinionated high-complexity guide

### DIFF
--- a/plugins/python/src/habit_hooks_python/guides/high-complexity.md
+++ b/plugins/python/src/habit_hooks_python/guides/high-complexity.md
@@ -1,0 +1,12 @@
+High cyclomatic complexity means one function is making too many decisions at once. The smell is not the number, it is that the function has quietly taken on more than one job. The count is the symptom, tangled responsibilities are the cause.
+
+{% include "includes/line_level_issues.md" %}
+Work through it in order:
+
+1. **Name what each branch is for.** Give every branch a one-sentence description of the responsibility it handles. If two branches describe the same thing, they belong together. If a branch has no clean name, that path probably wants its own function.
+2. **Lift the guards out first.** Turn early-exit conditions into guard clauses (`if not user: return None`) so the happy path stays flat and left-aligned. Most of the count is preconditions wrapped around the real work.
+3. **Change the shape, do not just move it.** A long `if/elif` on a value is often a dict dispatch or polymorphism. A nested loop is often a comprehension or a generator. Pull a coherent inner block into a named function. The goal is fewer decisions in one place, not the same decisions scattered across three helpers.
+
+Reducing the number without reducing the tangle is not a fix. Do not merge conditions with `and`/`or` just to drop a branch, and do not rewrite `if` statements as ternaries to slip under the check. ruff's mccabe does not count ternary expressions, so that trick lowers the score while a human still has to hold every condition in their head.
+
+The test is not whether the number dropped. It is whether someone reading the function for the first time can hold it in their head at once. If not, it is still doing too much.

--- a/plugins/python/src/habit_hooks_python/guides/high-complexity.md
+++ b/plugins/python/src/habit_hooks_python/guides/high-complexity.md
@@ -5,7 +5,7 @@ Work through it in order:
 
 1. **Name what each branch is for.** Give every branch a one-sentence description of the responsibility it handles. If two branches describe the same thing, they belong together. If a branch has no clean name, that path probably wants its own function.
 2. **Lift the guards out first.** Turn early-exit conditions into guard clauses (`if not user: return None`) so the happy path stays flat and left-aligned. Most of the count is preconditions wrapped around the real work.
-3. **Change the shape, do not just move it.** A long `if/elif` on a value is often a dict dispatch or polymorphism. A nested loop is often a comprehension or a generator. Pull a coherent inner block into a named function. The goal is fewer decisions in one place, not the same decisions scattered across three helpers.
+3. **Change the shape, do not just move it.** When every branch is the same kind of decision, reshape it: a long `if/elif` on a value is often a dict dispatch or polymorphism, a nested loop often a comprehension or a generator. When polymorphism is not the right fit and the branches are genuinely separate jobs, extract one named method per branch, each named for the responsibility it handles. The goal is fewer decisions in one place, not the same tangle split into `_part1` / `_part2` behind worse names.
 
 Reducing the number without reducing the tangle is not a fix. Do not merge conditions with `and`/`or` just to drop a branch, and do not rewrite `if` statements as ternaries to slip under the check. ruff's mccabe does not count ternary expressions, so that trick lowers the score while a human still has to hold every condition in their head.
 


### PR DESCRIPTION
## What this adds

An opinionated Python guide for `high-complexity` (ruff `C901`), so a python config coaches the smell with python-specific moves instead of the generic default. Same shape as the swallowed-exception guide.

## The coaching stance

The smell is tangled responsibilities, not the number itself. The guide gives three concrete moves: name each branch's responsibility (branches that share a name belong together; a branch with no name wants its own function), lift guards out into early returns so the happy path stays flat, and change the shape rather than just moving it. Reshape uniform branches into a dict dispatch, comprehension or polymorphism; when polymorphism is not the fit and the branches are genuinely separate jobs, extract one named method per branch by responsibility, not a mechanical `_part1`/`_part2` split. The test it leaves is whether a first-time reader can hold the function in their head.

## Anti-gaming

It calls out gaming the metric, including a specific one: ruff's mccabe does not count ternary expressions, so rewriting `if`s as ternaries lowers the C901 score while a human still has to hold every condition. Verified locally: a four-branch `if` chain scores 5 and trips C901 at max-complexity 3, while the equivalent ternary chain is not counted.

## Notes

- Uses the shared `{% include "includes/line_level_issues.md" %}` (now in core), consistent with the other guides.
- No spec test, matching the decision on the swallowed-exception guide (routing is already covered by the "a finding's language selects a plugin's guide" case).
