### PR TITLE
chore(project): adopt the recommended ruff thresholds and enforce them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: uv sync --frozen
+      - name: Lint (ruff)
+        run: uv run ruff check src
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,17 @@ DEP002 = [
     "habit-hooks-typescript",
     "habit-hooks-php",
 ]
+
+[tool.ruff.lint]
+# Dogfood the python plugin's recommended structural thresholds
+# (plugins/python/src/habit_hooks_python/ruff.toml). extend-select turns the
+# three checks on; the blocks below set the limits. Without extend-select the
+# thresholds are inert, so both parts are required.
+extend-select = ["C901", "PLR0913", "PLR0915"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 3
+max-statements = 12

--- a/src/habit_hooks/mapper.py
+++ b/src/habit_hooks/mapper.py
@@ -49,10 +49,8 @@ def include_environment(plugins: list[str], resolver: Resolver) -> Environment:
     return Environment(loader=FunctionLoader(load))
 
 
-def render_markdown(
-    guide: Path, finding: dict, plugins: list[str], resolver: Resolver
-) -> Rendered:
-    template = include_environment(plugins, resolver).from_string(guide.read_text())
+def render_markdown(guide: Path, finding: dict, environment: Environment) -> Rendered:
+    template = environment.from_string(guide.read_text())
     return Rendered(text=template.render(**finding), blocks=True)
 
 
@@ -78,7 +76,8 @@ def render_finding(finding: dict, config: Config, resolver: Resolver) -> Rendere
         guide = resolver.guide(UNCOACHED_GUIDE, config.plugins)
     extension = guide.suffix.lstrip(".")
     if extension == "md":
-        rendered = render_markdown(guide, finding, config.plugins, resolver)
+        environment = include_environment(config.plugins, resolver)
+        rendered = render_markdown(guide, finding, environment)
     else:
         rendered = render_runner(guide, config.runners[extension], finding)
     rendered.blocks = enforced and rendered.blocks


### PR DESCRIPTION
## What

habit-hooks recommends `max-complexity = 10`, `max-args = 3`, `max-statements = 12` (the python plugin's `ruff.toml`), but the project did not apply them to its own code. This makes the project follow its own recommendation and enforces it in CI.

## Changes

- **pyproject.toml**: add the three thresholds under `[tool.ruff.lint.*]`, plus `extend-select = ["C901", "PLR0913", "PLR0915"]`. The `extend-select` is required. Without it the thresholds are inert, because those checks are off by ruff's defaults.
- **ci.yml**: add a `uv run ruff check src` step so the values are actually enforced on pushes to main and on pull requests.
- **mapper.py**: adopting the thresholds flagged one real violation in the project's own code. `render_markdown` had four arguments. It only used `plugins` + `resolver` to build a jinja `Environment`, so it now takes the `Environment` (three args). Behaviour unchanged, mapper tests green.

## Notes

1. The CI lint is scoped to `src` on purpose. A repo-wide `ruff check .` currently fails, because ruff tries to parse the python plugin's sensor `ruff.toml` (a sensor definition, `command = """..."""`) as a ruff config. Widening the lint to the plugins would need that handled first (rename, or exclude it from config discovery). Happy to follow up separately.
2. This only touches the project's own config and one small internal refactor in the mapper (the flagged function and its single call site). It does not change the plugin's recommendation mechanism. That is the separate init question.
3. The `ruff check src` CI step is a suggestion, to keep the values from sitting decorative. If you would rather carry the config without enforcing it in CI yet, say the word and I will drop that step.

## Verified

- `uv run ruff check src` passes.
- The config is active, not decorative: a 4-argument probe is caught (`PLR0913`, 4 > 3), then removed.
- `uv run pytest plugins/python tests` green (37 passed, 1 skipped); mapper tests green (15 passed).
