### PR TITLE
docs(generic): coach the missing concept, not the parameter count

### DIFF
--- a/plugins/generic/src/habit_hooks_generic/guides/too-many-parameters.md
+++ b/plugins/generic/src/habit_hooks_generic/guides/too-many-parameters.md
@@ -1,13 +1,10 @@
-High parameter count is a sign of coupling.
-Parameters that travel together across several calls are a missing abstraction.
-
-**Find the missing abstraction:**
-1. Look at the call sites and nearby functions — is there an existing class a group of these parameters belongs to?
-2. If not, create it — then move behaviour that uses those fields onto it.
-3. If one object owns most of the parameters, it may be the natural home for this function.
-
-Useful tip: rewrite each call site with the signature that feels natural there, and let that shape the final method. 
-
-**AVOID**: A `{ ...everything }` bag that merely renames the list hides the coupling instead of removing it.
+A long parameter list is the symptom. The defect is a concept with no name — values that always travel together and were never made a thing.
 
 {% include "includes/line_level_issues.md" %}
+Grouping them into a bag named after the function that takes them — a `FooProps`, an options object, `{ ...everything }` — clears the report and entrenches the smell. Such an object is organised by method rather than by abstraction: the next function invents another bag, and the concept stays unnamed.
+
+Name the entity instead, and use domain-driven design to find it: parameters that travel together are usually one of the domain's own nouns. Search the rest of the codebase for the same values appearing side by side — the combinations that recur are the real entity, and where one already carries a name, that name is the answer. Then ask whether this function belongs *on* it.
+
+Refactor every site the new entity fits, not only the one that fired. An abstraction used in one place is hidden, not introduced, and a call passing three of its fields is the same concept sitting under the threshold.
+
+Done right: the entity carries a domain name, its call sites read as statements about it, and nowhere in the codebase still passes its fields loose.


### PR DESCRIPTION
## The problem

The guide already asks for a better object, but the agent's default answer to it is a **bag named after the function that takes it** — a `FooProps`, an options object, `{ ...everything }`. That clears the report and entrenches the smell: such an object is organised by *method* rather than by *abstraction*, so the next function invents another bag and the concept stays unnamed.

## What I measured

On a real TypeScript codebase (a thumbnail editor, ~900 tests), five parameter lists were over the threshold. **Three of the five re-listed the members of an entity the codebase had already named somewhere else** — the props interface spelled out the fields instead of taking the existing type. The other two pointed at one concept that appeared independently in two files and had no name at all.

The tell was mechanical in one case: the component immediately passed four of its five props straight back out to a hook. Values that arrive together and leave together are an entity.

## What the guide now says

Three additions, all terse, keeping the existing ROSE shape:

1. **Names domain-driven design** as the tool for finding the entity — parameters that travel together are usually one of the domain's own nouns.
2. **Says to search the rest of the codebase** for the same values appearing side by side. The combinations that recur are the real entity, and where one already carries a name, that name is the answer.
3. **Requires refactoring every site the entity fits**, not only the line that fired. An abstraction used in one place is hidden, not introduced, and a call passing three of its fields is the same concept sitting under the threshold.

## Testing

`uv run pytest` — the generic plugin's suite passes. 16 failures in `plugins/typescript` are identical with and without this change on `origin/main` (knip and comment sensors); they are not touched here.

## Related

There is a blind spot no guide can reach: `max-params` counts *parameters*, so a props object is one parameter however many values it carries, and the guide never fires. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb1JpxqxY9mtqzXgQKdBYS
