### PR TITLE
feat(plugins): The java plugin — PMD-backed structural smell detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
         run: |
           corepack enable pnpm
           pnpm install --frozen-lockfile
+      - name: Install pmd
+        # The java plugin's sensor and its spec cases need the real PMD on PATH.
+        run: |
+          curl -fsSLo /tmp/pmd.zip https://github.com/pmd/pmd/releases/download/pmd_releases%2F7.26.0/pmd-dist-7.26.0-bin.zip
+          unzip -q /tmp/pmd.zip -d /tmp/pmd
+          echo "/tmp/pmd/pmd-bin-7.26.0/bin" >> "$GITHUB_PATH"
       - name: Test
         run: uv run pytest
       # Dogfooding: habit-hooks gates its own source. Without this the tool can

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           - { dist: habit_hooks_python, environment: pypi-python }
           - { dist: habit_hooks_typescript, environment: pypi-typescript }
           - { dist: habit_hooks_php, environment: pypi-php }
+          - { dist: habit_hooks_java, environment: pypi-java }
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ nothing and only reports what is missing, so it also answers "why is this run no
 Setting habit-hooks up takes four steps. A run that reports nothing is almost always a skipped one:
 
 1. **Install habit-hooks** — you get the core and the generic, language-agnostic plugin.
-2. **Install the plugin for your language** — python, typescript and php ship as separate packages.
+2. **Install the plugin for your language** — python, typescript, php and java ship as separate packages.
 3. **Enable the plugins** by naming them in `.habit-hooks/config.toml`. Installing one does not switch it on.
 4. **Install the detectors** the plugins you enabled use — `jscpd`, `ruff`, `eslint` and friends.
 
@@ -97,17 +97,17 @@ This gives you **core plus the generic (language-agnostic) plugin** and installs
 all four plugins, so skip to step 3.
 
 > ⚠️ **Important: this on its own checks nothing about your language.** What you have now is the generic
-> plugin, which measures file length and duplication. Python, TypeScript and PHP each need their own plugin —
-> installed (step 2) *and* enabled (step 3).
+> plugin, which measures file length and duplication. Python, TypeScript, PHP and Java each need their own
+> plugin — installed (step 2) *and* enabled (step 3).
 
 ### 2. Install the plugin for your language
 
-The three language plugins are **opt-in** via extras:
+The four language plugins are **opt-in** via extras:
 
 ```sh
 uv tool install "habit-hooks[typescript]"          # one language
 uv tool install "habit-hooks[python,typescript]"   # several — name them in one command
-uv tool install "habit-hooks[all]"                 # all three
+uv tool install "habit-hooks[all]"                 # all four
 ```
 
 > ⚠️ Each `uv tool install` **rebuilds** the environment rather than adding to it, so a second one naming a
@@ -242,7 +242,7 @@ A plugin is not a language — it *declares* the language it speaks in its `conf
 onto the plugin's findings. So several plugins can speak the same language using different tools, and the order
 decides which one's guide wins. `generic` is listed explicitly like any other plugin, so a project can drop it.
 
-The four plugins that ship:
+The five plugins that ship:
 
 | Plugin | Language | Sensors | Tools used |
 |--------|----------|---------|------------|
@@ -250,6 +250,7 @@ The four plugins that ship:
 | `python` | `python` | `ruff`, `deptry` | ruff, deptry |
 | `typescript` | `typescript` | `eslint`, `knip`, `comment` | eslint, knip, ts-morph |
 | `php` | `php` | `phpmd` | phpmd |
+| `java` | `java` | `pmd` | pmd |
 
 ## Overrides: tune without forking
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -83,7 +83,7 @@ pip install "habit-hooks[python,typescript]" # several at once
 ```
 
 The `generic` plugin ships as part of the core install; each extra (`python`,
-`typescript`, `php`) installs the matching
+`typescript`, `php`, `java`) installs the matching
 `habit-hooks-<name>` distribution; a third-party plugin is just a package you
 `pip install habit-hooks-<name>` directly. The core then finds every installed
 plugin through its entry point — nothing else is configured for discovery.

--- a/docs/smell-vocabulary.md
+++ b/docs/smell-vocabulary.md
@@ -148,6 +148,33 @@ list alongside `php` to get it. PHPMD's `NPathComplexity` overlaps
 `CyclomaticComplexity`, so only the latter is mapped to avoid double-reporting the
 same function.
 
+## Java plugin translation
+
+The raw rule names PMD emits, and the smell key each maps to (the rest of the
+catalogue is shared — only the plugin's sensors differ).
+
+| Raw key (tool:rule)         | Smell key             |
+|-----------------------------|-----------------------|
+| `pmd:ExcessiveParameterList` | `too-many-parameters` |
+| `pmd:CyclomaticComplexity`   | `high-complexity`     |
+| `pmd:NcssCount`              | `oversized-function`  |
+| `pmd:UnusedLocalVariable`    | `unused-variable`     |
+| `pmd:UnnecessaryImport`      | `unused-import`       |
+| `pmd:EmptyCatchBlock`        | `swallowed-exception` |
+
+The Java plugin runs PMD (`pmd check --format json`) through a thin sensor that
+normalises PMD's exit-4-on-violations and maps its rule names to canonical smells.
+PMD 7 no longer ships `ExcessiveMethodLength`/`ExcessiveClassLength`, so
+`oversized-function` comes from `NcssCount`, which reports classes, methods and
+constructors off one rule — the sensor keeps only the method/constructor
+violations (PMD's own message distinguishes them) and drops the class-level ones.
+PMD never discovers a project ruleset, so the sensor reaches for one only after
+checking the conventional locations (`src/main/resources/pmd/ruleset.xml`,
+`pmd/ruleset.xml`, `ruleset.xml`, `pmd.xml`) or a `--rulesets` in its args, then
+falls back to the bundled `pmd-ruleset.xml` — a project's own ruleset wins
+([config.md](config.md)). PMD 7's `UnnecessaryImport` is the renamed
+`UnusedImports`.
+
 ## Uncoached smells
 
 A smell with no entry above still renders — through the generic `uncoached.md`

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -19,6 +19,7 @@ plugin. Language plugins are opt-in extras:
 - `habit-hooks[python]`
 - `habit-hooks[typescript]`
 - `habit-hooks[php]`
+- `habit-hooks[java]`
 - `habit-hooks[all]`
 
 Project: https://github.com/habit-hooks/habit-hooks

--- a/packaging/npm/bin/habit-hooks.js
+++ b/packaging/npm/bin/habit-hooks.js
@@ -23,6 +23,7 @@ plugin. Language plugins are opt-in extras:
   habit-hooks[python]
   habit-hooks[typescript]
   habit-hooks[php]
+  habit-hooks[java]
   habit-hooks[all]
 
 Project: https://github.com/habit-hooks/habit-hooks

--- a/plugins/java/docs/java-plugin.spec.md
+++ b/plugins/java/docs/java-plugin.spec.md
@@ -1,0 +1,176 @@
+# The java plugin — acceptance
+
+The java plugin runs its sensor through the real `habit-sensors` pipeline. These
+cases run the **actual** tool (PMD, from the system `PATH`) against a fixture
+with a known smell and assert the canonical finding comes out, mapped to the
+smell keys in [smell-vocabulary.md](smell-vocabulary.md).
+
+`habit-sensors` is the installed CLI; `pmd` is on the system `PATH`. The sensor
+runs `pmd check --format json`, normalises PMD's exit-4-on-violations into a
+clean run, and reaches for a ruleset the project wrote only after checking the
+conventional Java locations, then falls back to the bundled `pmd-ruleset.xml`
+when the project has none (PMD itself never discovers one).
+
+📄.habit-hooks/config.toml
+```toml
+plugins = ["java"]
+```
+
+## pmd sensor maps rule names to canonical smells
+
+The `pmd` sensor runs PMD with the bundled fallback ruleset and shapes each
+violation into one finding per smell, stamping `source: "pmd:<rule>"` on each
+issue. A five-parameter constructor trips `ExcessiveParameterList` →
+`too-many-parameters`, an unused import trips `UnnecessaryImport` →
+`unused-import`, and a dead local trips `UnusedLocalVariable` →
+`unused-variable`.
+
+📄Billing.java
+```java
+import java.io.File;
+import java.io.IOException;
+class Billing {
+    double charge(double a, double b, double c, double d, double e) {
+        int dead = 1;
+        return a + b + c + d + e;
+    }
+}
+```
+
+```bash
+habit-sensors --all | jq 'sort_by(.smell)[] | {smell, language, key: (.issues[0].key | sub(".*/"; "")), line: .issues[0].details.line, source: .issues[0].details.source}'
+```
+
+🖥️ ✅
+```json
+{
+  "smell": "too-many-parameters",
+  "language": "java",
+  "key": "Billing.java",
+  "line": 4,
+  "source": "pmd:ExcessiveParameterList"
+}
+{
+  "smell": "unused-import",
+  "language": "java",
+  "key": "Billing.java",
+  "line": 1,
+  "source": "pmd:UnnecessaryImport"
+}
+{
+  "smell": "unused-variable",
+  "language": "java",
+  "key": "Billing.java",
+  "line": 5,
+  "source": "pmd:UnusedLocalVariable"
+}
+```
+
+## pmd sensor maps a deeply-branched method to high-complexity
+
+A method whose conditions are littered with `||` exceeds PMD's cyclomatic
+complexity threshold, tripping `CyclomaticComplexity` → `high-complexity` — while
+staying short enough on NCSS that the method is not also flagged oversized.
+
+📄Report.java
+```java
+class Report {
+    int classify(int n) {
+        if (n == 1 || n == 2 || n == 3 || n == 4 || n == 5) return 1;
+        if (n == 6 || n == 7 || n == 8 || n == 9 || n == 10) return 2;
+        if (n == 11 || n == 12 || n == 13 || n == 14 || n == 15) return 3;
+        if (n == 16 || n == 17 || n == 18) return 4;
+        return 0;
+    }
+}
+```
+
+```bash
+habit-sensors --all | jq '.[] | {smell, language, source: .issues[0].details.source}'
+```
+
+🖥️ ✅
+```json
+{
+  "smell": "high-complexity",
+  "language": "java",
+  "source": "pmd:CyclomaticComplexity"
+}
+```
+
+## A project's own ruleset wins over the bundled one
+
+PMD never discovers a project ruleset, so the sensor reaches for one only where
+the Java ecosystem conventionally keeps it. A `src/main/resources/pmd/ruleset.xml`
+that lowers the parameter threshold is in force for the run — the bundled
+fallback is only the answer to "this project has none".
+
+📄src/main/resources/pmd/ruleset.xml
+```xml
+<?xml version="1.0"?>
+<ruleset name="custom" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+ <description>two parameters is already too many</description>
+ <rule ref="category/java/design.xml/ExcessiveParameterList">
+  <properties><property name="minimum" value="2"/></properties>
+ </rule>
+</ruleset>
+```
+
+📄Project.java
+```java
+class Project {
+    void save(String a, String b) {
+    }
+}
+```
+
+```bash
+habit-sensors --all | jq '.[] | {smell, language, key: (.issues[0].key | sub(".*/"; ""))}'
+```
+
+🖥️ ✅
+```json
+{
+  "smell": "too-many-parameters",
+  "language": "java",
+  "key": "Project.java"
+}
+```
+
+## A crashing pmd fails the run, never reports clean
+
+PMD exits non-zero on a file it cannot parse. The sensor surfaces that as a
+failure — a crashed tool is never a clean run. It exits with a code outside the
+findings range, so `habit-sensors` raises, names the sensor on stderr, and exits
+1 rather than printing an empty (false-clean) result. The failed run carries only
+the reserved `incomplete-run` marker on stdout
+([habit-sensors.spec.md](../../../docs/habit-sensors.spec.md)).
+
+The notice carries PMD's own diagnosis after that first line.
+
+📄broken.java
+```java
+class Broken {
+    void oops( {
+}
+```
+
+```bash
+habit-sensors --all | jq -c '[.[].smell]'
+```
+
+🖥️ ❌ 1
+```json
+["incomplete-run"]
+```
+
+```bash
+habit-sensors --all 2>&1 >/dev/null | sed -n 1p
+```
+
+🖥️ ❌ 1
+```text
+habit-sensors: sensor 'pmd' failed: ${python} ${dir}/pmd_sensor.py ${args} ${files}
+```

--- a/plugins/java/pyproject.toml
+++ b/plugins/java/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "habit-hooks-java"
+version = "1.2.1"
+description = "The Java Habit Hooks plugin"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.entry-points."habit_hooks.plugins"]
+java = "habit_hooks_java"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/habit_hooks_java"]

--- a/plugins/java/src/habit_hooks_java/__init__.py
+++ b/plugins/java/src/habit_hooks_java/__init__.py
@@ -1,0 +1,1 @@
+"""The java Habit Hooks plugin: package data discovered via the habit_hooks.plugins entry point."""

--- a/plugins/java/src/habit_hooks_java/config.toml
+++ b/plugins/java/src/habit_hooks_java/config.toml
@@ -1,0 +1,4 @@
+language = "java"
+files = ["**/*.java"]
+sensors = ["pmd"]
+transformers = []

--- a/plugins/java/src/habit_hooks_java/sensors/pmd-ruleset.xml
+++ b/plugins/java/src/habit_hooks_java/sensors/pmd-ruleset.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="habit-hooks"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+  <description>Habit-hooks structural smell rules. Reached for only when the
+  project names no PMD ruleset of its own; a project's own ruleset wins.</description>
+  <rule ref="category/java/design.xml/ExcessiveParameterList">
+    <properties><property name="minimum" value="4"/></properties>
+  </rule>
+  <rule ref="category/java/design.xml/CyclomaticComplexity">
+    <properties><property name="methodReportLevel" value="10"/></properties>
+  </rule>
+  <rule ref="category/java/design.xml/NcssCount">
+    <properties><property name="methodReportLevel" value="12"/></properties>
+  </rule>
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryImport"/>
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
+</ruleset>

--- a/plugins/java/src/habit_hooks_java/sensors/pmd.toml
+++ b/plugins/java/src/habit_hooks_java/sensors/pmd.toml
@@ -1,0 +1,1 @@
+command = "${python} ${dir}/pmd_sensor.py ${args} ${files}"

--- a/plugins/java/src/habit_hooks_java/sensors/pmd_sensor.py
+++ b/plugins/java/src/habit_hooks_java/sensors/pmd_sensor.py
@@ -1,0 +1,170 @@
+"""Run PMD and print canonical smell findings.
+
+PMD exits 4 when it finds violations, 0 when clean, and 1/2/5 on exceptions,
+usage errors and recoverable errors (since 7.3.0) — so a bare pipe cannot tell
+a clean run from a crash. This wrapper runs PMD against the scoped files,
+treats only 0/4 as success, and shapes each violation into the canonical
+finding, mapping PMD rule names to smell keys.
+
+PMD never discovers a project ruleset on its own — ``-R`` is required — so the
+ruleset is resolved here: a ``--rulesets`` among the sensor's ``args`` (the
+project naming its config explicitly) wins; then the first conventional ruleset
+file the Java ecosystem's build tools point at, in the project directory only;
+then the plugin's bundled ``pmd-ruleset.xml`` as the answer to "the project has
+none".
+
+PMD 7's picocli reads a positional path that directly follows the ruleset value
+as another ``-R`` value (``-R ruleset.xml file.java`` analyses nothing), so the
+wrapper uses the short forms ``-R`` and per-file ``-d``, which do not. Verified
+against PMD 7.26.0.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+RULE_SMELLS = {
+    "ExcessiveParameterList": "too-many-parameters",
+    "CyclomaticComplexity": "high-complexity",
+    "NcssCount": "oversized-function",
+    "UnusedLocalVariable": "unused-variable",
+    "UnnecessaryImport": "unused-import",
+    "EmptyCatchBlock": "swallowed-exception",
+}
+
+# NcssCount reports classes, methods and constructors off one rule, and the
+# catalogue has a smell only for oversized methods, so class-level violations
+# are dropped. The distinction lives in PMD's own message template, which is
+# the only structural signal the JSON report carries for it.
+METHOD_NCSS_PREFIXES = ("The method", "The constructor")
+
+# The ruleset names Maven and Gradle PMD setups conventionally point at, in
+# the order a project directory is checked. PMD itself offers no discovery
+# signal (it never looks one up), so this is the knip-shaped search for the
+# project's own config; a ``--rulesets`` in the sensor's args overrides it.
+RULESET_LOCATIONS = (
+    "src/main/resources/pmd/ruleset.xml",
+    "pmd/ruleset.xml",
+    "ruleset.xml",
+    "pmd.xml",
+)
+
+SUCCESS_EXIT_CODES = (0, 4)
+RULESET_OPTIONS = ("--rulesets", "-R")
+
+
+def run_pmd(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    """What PMD said, or what a shell says about a PMD nobody installed.
+
+    The plugin does not ship the distribution, so ``pmd`` is the command that
+    goes missing — and an absent one raised a ``FileNotFoundError`` out of
+    here, making twenty lines of Python internals the sensor's diagnosis
+    (#114). This wrapper is what looks for pmd, so it answers the way the
+    shell would have, and that phrase is what the run recognises to name the
+    missing tool.
+    """
+    command = ["pmd", "check", "--no-cache", "--format", "json"]
+    try:
+        return subprocess.run(
+            [*command, *arguments], capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(command, 127, "", "pmd: command not found\n")
+
+
+def ruleset_of(argv: list[str], project: Path) -> tuple[Path, list[str]]:
+    """The ruleset in force, and the remaining args with no ruleset named.
+
+    A ``--rulesets``/``-R`` among the sensor's args is the project's own config
+    and wins over everything; PMD only ever gets one, so it is pulled out of
+    the tail rather than left beside the wrapper's own.
+    """
+    for i, token in enumerate(argv):
+        if token in RULESET_OPTIONS and i + 1 < len(argv):
+            return Path(argv[i + 1]), [*argv[:i], *argv[i + 2 :]]
+        if token.startswith("--rulesets="):
+            return Path(token.split("=", 1)[1]), [*argv[:i], *argv[i + 1 :]]
+    for name in RULESET_LOCATIONS:
+        if (project / name).is_file():
+            return project / name, argv
+    return Path(__file__).with_name("pmd-ruleset.xml"), argv
+
+
+def violations(report: dict) -> list[dict]:
+    return [
+        {"file": entry["filename"], "violation": violation}
+        for entry in report.get("files", [])
+        for violation in entry["violations"]
+    ]
+
+
+def smell_of(entry: dict) -> str | None:
+    violation = entry["violation"]
+    rule = violation["rule"]
+    if rule == "NcssCount" and not violation["description"].startswith(
+        METHOD_NCSS_PREFIXES
+    ):
+        return None
+    return RULE_SMELLS.get(rule)
+
+
+def issue(entry: dict) -> dict:
+    violation = entry["violation"]
+    return {
+        "key": entry["file"],
+        "details": {
+            "file": entry["file"],
+            "line": violation["beginline"],
+            "message": violation["description"],
+            "source": "pmd:" + violation["rule"],
+        },
+    }
+
+
+def findings(entries: list[dict]) -> list[dict]:
+    by_smell: dict[str, list[dict]] = {}
+    for entry in entries:
+        smell = smell_of(entry)
+        if smell is not None:
+            by_smell.setdefault(smell, []).append(issue(entry))
+    return [
+        {"smell": smell, "details": {}, "issues": issues}
+        for smell, issues in by_smell.items()
+    ]
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if not argv:
+        print("[]")
+        return 0
+    ruleset, arguments = ruleset_of(argv, Path.cwd())
+    file_args = [token for argument in arguments for token in ("-d", argument)]
+    result = run_pmd(["-R", str(ruleset), *file_args])
+    if result.returncode not in SUCCESS_EXIT_CODES:
+        sys.stderr.write(processing_errors(result.stdout) or result.stderr or result.stdout)
+        return 2
+    print(json.dumps(findings(violations(json.loads(result.stdout)))))
+    return 0
+
+
+def processing_errors(stdout: str) -> str:
+    """What a non-successful run actually failed on.
+
+    PMD's own stderr on a recoverable error is a generic "an error occurred,
+    report a bug" — while the JSON report it still writes to stdout names the
+    file and the parse failure. That message is the one a reader can act on.
+    """
+    try:
+        report = json.loads(stdout)
+    except json.JSONDecodeError:
+        return ""
+    errors = report.get("processingErrors", [])
+    return "".join(f"{entry['filename']}: {entry['message']}\n" for entry in errors)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/java/tests/test_a_java_pmd_nobody_installed_is_named.py
+++ b/plugins/java/tests/test_a_java_pmd_nobody_installed_is_named.py
@@ -1,0 +1,35 @@
+"""The tool this plugin does not ship must still answer in one line.
+
+The plugin does not bundle the PMD distribution, so ``pmd`` is the command that
+goes missing — and it is spawned from Python, where an absent tool is a
+``FileNotFoundError`` and twenty lines of internals would otherwise become the
+sensor's diagnosis (#114).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SENSOR = (
+    Path(__file__).resolve().parents[1] / "src/habit_hooks_java/sensors/pmd_sensor.py"
+)
+
+
+def test_a_java_pmd_nobody_installed_answers_the_way_a_shell_does(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "App.java").write_text("class App {}\n")
+
+    result = subprocess.run(
+        [sys.executable, str(SENSOR), "App.java"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/nonexistent"},
+    )
+
+    assert result.returncode != 0
+    assert result.stdout.strip() == ""
+    assert result.stderr.strip() == "pmd: command not found"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,12 @@ dependencies = [
 python = ["habit-hooks-python~=1.2"]
 typescript = ["habit-hooks-typescript~=1.2"]
 php = ["habit-hooks-php~=1.2"]
+java = ["habit-hooks-java~=1.2"]
 all = [
     "habit-hooks-python~=1.2",
     "habit-hooks-typescript~=1.2",
     "habit-hooks-php~=1.2",
+    "habit-hooks-java~=1.2",
 ]
 
 [project.scripts]
@@ -47,6 +49,7 @@ habit-hooks-generic = { workspace = true }
 habit-hooks-python = { workspace = true }
 habit-hooks-typescript = { workspace = true }
 habit-hooks-php = { workspace = true }
+habit-hooks-java = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -58,6 +61,7 @@ dev = [
     "habit-hooks-python",
     "habit-hooks-typescript",
     "habit-hooks-php",
+    "habit-hooks-java",
 ]
 
 [tool.pytest.ini_options]
@@ -79,6 +83,7 @@ DEP002 = [
     "habit-hooks-python",
     "habit-hooks-typescript",
     "habit-hooks-php",
+    "habit-hooks-java",
 ]
 
 [tool.ruff.lint]

--- a/skills/release-habit-hooks/SKILL.md
+++ b/skills/release-habit-hooks/SKILL.md
@@ -5,9 +5,10 @@ description: "Cut a new release of the habit-hooks packages. Use when asked to r
 
 # Release Habit Hooks
 
-Five packages ship from this repo: `habit-hooks` (core), `habit-hooks-generic`,
-`habit-hooks-python`, `habit-hooks-typescript`, `habit-hooks-php`. A `v*` tag
-triggers `.github/workflows/release.yml`, which builds all five and publishes
+Six packages ship from this repo: `habit-hooks` (core), `habit-hooks-generic`,
+`habit-hooks-python`, `habit-hooks-typescript`, `habit-hooks-php`,
+`habit-hooks-java`. A `v*` tag
+triggers `.github/workflows/release.yml`, which builds all six and publishes
 each with `skip-existing: true` — so an unchanged package at an already-published
 version is simply skipped. Publishing is irreversible: **never tag or push
 without Ivett's explicit go-ahead.**

--- a/src/habit_hooks/recommend.py
+++ b/src/habit_hooks/recommend.py
@@ -30,6 +30,7 @@ LANGUAGE_SIGNALS = (
     LanguageSignal("python", ("pyproject.toml",), (".py",)),
     LanguageSignal("typescript", ("tsconfig.json",), (".ts", ".tsx")),
     LanguageSignal("php", ("composer.json",), (".php",)),
+    LanguageSignal("java", ("pom.xml", "build.gradle", "build.gradle.kts"), (".java",)),
 )
 
 

--- a/tests/installed_env.py
+++ b/tests/installed_env.py
@@ -45,6 +45,13 @@ def require_tool(name: str) -> str:
     return tool
 
 
+def require_pmd() -> str:
+    pmd = shutil.which("pmd")
+    if pmd is None:
+        pytest.skip("pmd is not on PATH")
+    return pmd
+
+
 def _uv_run(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [require_uv(), *args], check=True, capture_output=True, text=True

--- a/tests/test_installed_wheel_smoke_java.py
+++ b/tests/test_installed_wheel_smoke_java.py
@@ -1,0 +1,64 @@
+"""End-to-end smoke test of the java plugin against its installed wheel.
+
+The java sensor reaches for a ruleset it ships when the project names none, so
+the bundled ``pmd-ruleset.xml`` must ride along as package data — exactly as the
+php case proves for its bundled phar. Building and installing is
+``installed_env``; this module is only what an installed run must produce.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from installed_env import (
+    build_wheels,
+    install_wheels,
+    require_pmd,
+    run_and_collect_findings,
+)
+
+
+@pytest.fixture(scope="module")
+def installed_habit_sensors(tmp_path_factory) -> Path:
+    root = tmp_path_factory.mktemp("java-wheel-smoke")
+    wheels_dir = root / "wheels"
+    wheels_dir.mkdir()
+    build_wheels(wheels_dir, ("habit-hooks", "habit-hooks-generic", "habit-hooks-java"))
+    return install_wheels(root / "venv", wheels_dir)
+
+
+def _java_project(tmp_path: Path) -> Path:
+    project = tmp_path / "java-proj"
+    project.mkdir()
+    config = project / ".habit-hooks"
+    config.mkdir()
+    (config / "config.toml").write_text('plugins = ["java"]\n')
+    (project / "Billing.java").write_text(
+        "import java.io.File;\n"
+        "import java.io.IOException;\n"
+        "class Billing {\n"
+        "    double charge(double a, double b, double c, double d, double e) {\n"
+        "        int dead = 1;\n"
+        "        return a + b + c + d + e;\n"
+        "    }\n"
+        "}\n"
+    )
+    return project
+
+
+def test_installed_java_plugin_locates_its_bundled_ruleset(
+    installed_habit_sensors: Path, tmp_path: Path
+) -> None:
+    require_pmd()
+    findings = run_and_collect_findings(
+        installed_habit_sensors, _java_project(tmp_path)
+    )
+
+    by_smell = {finding["smell"]: finding for finding in findings}
+    assert by_smell.keys() == {"too-many-parameters", "unused-import", "unused-variable"}
+    for finding in findings:
+        assert finding["language"] == "java"
+        issue = finding["issues"][0]
+        assert Path(issue["key"]).name == "Billing.java"
+        assert issue["details"]["source"].startswith("pmd:")

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -56,6 +56,23 @@ def test_an_unused_language_is_not_recommended(tmp_path: Path) -> None:
     assert recommendations(tmp_path, ["src/app.rb"], PluginStatus(set(), _on_hand())) == []
 
 
+def test_a_java_project_is_recommended_java(tmp_path: Path) -> None:
+    """A `pom.xml` or `build.gradle` — the two build tools that own the
+    ecosystem — counts as java, as does any `.java` file in scope."""
+    (tmp_path / "pom.xml").write_text("<project/>")
+    assert recommendations(tmp_path, [], PluginStatus(set(), _on_hand())) == [
+        "habit-sensors: detected java; "
+        "consider `pip install habit-hooks-java`, "
+        'then add "java" to `plugins` in .habit-hooks/config.toml'
+    ]
+
+    (tmp_path / "pom.xml").unlink()
+    (tmp_path / "build.gradle.kts").write_text("")
+    assert recommendations(tmp_path, [], PluginStatus(set(), _on_hand())) != []
+    assert recommendations(tmp_path, [], PluginStatus({"java"}, _on_hand("java"))) == []
+    assert recommendations(tmp_path, ["src/App.java"], PluginStatus(set(), _on_hand())) != []
+
+
 def test_a_vendored_plugin_counts_as_installed(tmp_path: Path) -> None:
     """``Resolver.has_plugin`` is the question, so a plugin vendored under
     ``.habit-hooks/<name>/`` — the install route the README offers where extras

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 members = [
     "habit-hooks",
     "habit-hooks-generic",
+    "habit-hooks-java",
     "habit-hooks-php",
     "habit-hooks-python",
     "habit-hooks-typescript",
@@ -84,9 +85,13 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "habit-hooks-java" },
     { name = "habit-hooks-php" },
     { name = "habit-hooks-python" },
     { name = "habit-hooks-typescript" },
+]
+java = [
+    { name = "habit-hooks-java" },
 ]
 php = [
     { name = "habit-hooks-php" },
@@ -102,6 +107,7 @@ typescript = [
 dev = [
     { name = "deptry" },
     { name = "habit-hooks-generic" },
+    { name = "habit-hooks-java" },
     { name = "habit-hooks-php" },
     { name = "habit-hooks-python" },
     { name = "habit-hooks-typescript" },
@@ -114,6 +120,8 @@ dev = [
 requires-dist = [
     { name = "attrs", specifier = ">=23" },
     { name = "habit-hooks-generic", editable = "plugins/generic" },
+    { name = "habit-hooks-java", marker = "extra == 'all'", editable = "plugins/java" },
+    { name = "habit-hooks-java", marker = "extra == 'java'", editable = "plugins/java" },
     { name = "habit-hooks-php", marker = "extra == 'all'", editable = "plugins/php" },
     { name = "habit-hooks-php", marker = "extra == 'php'", editable = "plugins/php" },
     { name = "habit-hooks-python", marker = "extra == 'all'", editable = "plugins/python" },
@@ -123,12 +131,13 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3" },
     { name = "pathspec", specifier = ">=0.12" },
 ]
-provides-extras = ["python", "typescript", "php", "all"]
+provides-extras = ["python", "typescript", "php", "java", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "deptry", specifier = ">=0.25.1" },
     { name = "habit-hooks-generic", editable = "plugins/generic" },
+    { name = "habit-hooks-java", editable = "plugins/java" },
     { name = "habit-hooks-php", editable = "plugins/php" },
     { name = "habit-hooks-python", editable = "plugins/python" },
     { name = "habit-hooks-typescript", editable = "plugins/typescript" },
@@ -141,6 +150,11 @@ dev = [
 name = "habit-hooks-generic"
 version = "1.2.1"
 source = { editable = "plugins/generic" }
+
+[[package]]
+name = "habit-hooks-java"
+version = "1.2.1"
+source = { editable = "plugins/java" }
 
 [[package]]
 name = "habit-hooks-php"


### PR DESCRIPTION
## What the PR does

Adds a fifth language plugin: `habit-hooks-java`. It runs **PMD** against the
project's Java sources and translates PMD rule violations into the core's
canonical smell vocabulary, so Java code gets the same coaching pipeline as
python/typescript/php.

The plugin is a separately-installable dist `habit-hooks-java` discovered via the
`habit_hooks.plugins` entry-point group — same architecture as the other plugins,
never a walk of a sibling directory.

### New files (`plugins/java/`)

- `pyproject.toml` — dist `habit-hooks-java` v1.1.0, entry point `java = "habit_hooks_java"`, ships package data.
- `src/habit_hooks_java/config.toml` — `language = "java"`, `files = ["**/*.java"]`, `sensors = ["pmd"]`.
- `src/habit_hooks_java/sensors/pmd.toml` — the sensor spec: `${python} ${dir}/pmd_sensor.py ${args} ${files}`.
- `src/habit_hooks_java/sensors/pmd_sensor.py` — the wrapper (170 lines):
  - runs `pmd check --no-cache --format json` (per-file `-d`, short `-R`, because PMD 7's picocli would read a positional path right after the ruleset value as another `-R`);
  - normalises PMD's **exit-4-on-violations** into a clean run (0 and 4 are success);
  - maps rule names → smells: `ExcessiveParameterList`→`too-many-parameters`, `CyclomaticComplexity`→`high-complexity`, `NcssCount`→`oversized-function`, `UnusedLocalVariable`→`unused-variable`, `UnnecessaryImport`→`unused-import`, `EmptyCatchBlock`→`swallowed-exception`;
  - keeps only method/constructor `NcssCount` violations (class-level ones are dropped — no catalogue smell for them; PMD's own message distinguishes them);
  - answers `pmd: command not found` the way a shell would when PMD is absent (#114 seam), so a missing detector is named, not a 20-line traceback;
  - on a non-successful PMD run, surfaces PMD's processing-error message from the JSON report rather than its generic stderr.
- `src/habit_hooks_java/sensors/pmd-ruleset.xml` — the **bundled fallback** ruleset (the answer to "project has none"). Project rulesets win: a `--rulesets`/`-R` in the sensor's args first, then conventional locations in the project dir (`src/main/resources/pmd/ruleset.xml`, `pmd/ruleset.xml`, `ruleset.xml`, `pmd.xml`), because PMD itself never discovers one.
- `docs/java-plugin.spec.md` — acceptance spec (also user-facing docs): rule→smell mapping, high-complexity mapping, "a project's own ruleset wins", "a crashing pmd fails the run, never reports clean".
- `tests/test_a_java_pmd_nobody_installed_is_named.py` — PMD absent → `pmd: command not found`, empty stdout, non-zero exit.

### Changes to existing files

- `pyproject.toml` — `java` extra (`habit-hooks-java~=1.0`), added to `all`, dev group, deptry DEP002, workspace member.
- `src/habit_hooks/recommend.py` — java `LanguageSignal` (`pom.xml` / `build.gradle` / `build.gradle.kts`, `.java`): a java project gets told to install/enable the plugin.
- `tests/test_recommend.py` — covers the java recommendation (and that it goes quiet once installed/enabled).
- `tests/installed_env.py` — `require_pmd()` skip-guard; `tests/test_installed_wheel_smoke_java.py` — end-to-end smoke: builds+installs the core, generic and java wheels into a throwaway venv and asserts the real findings come out with the bundled ruleset (proves the ruleset rides along as package data).
- `docs/smell-vocabulary.md` — "Java plugin translation" table (rule → smell), notes on `NcssCount`, ruleset resolution, `UnnecessaryImport` = renamed `UnusedImports`.
- `docs/config.md`, `README.md`, `packaging/npm/README.md`, `packaging/npm/bin/habit-hooks.js` — the `java` extra listed everywhere extras are.
- `.github/workflows/ci.yml` — installs PMD 7.26.0 on PATH for tests + dogfooding.
- `.github/workflows/release.yml` — sixth package `habit_hooks_java` → its own `pypi-java` environment (trusted publishers are unique per environment).
- `skills/release-habit-hooks/SKILL.md` — five → six packages.
- `uv.lock` — locked `habit-hooks-java`.

## What we verified

### Toolchain / install (the non-obvious part — java isn't published yet)

1. Installed `uv` (was not on PATH).
2. Installed **PMD 7.26.0** from the official GitHub release zip to `~/.local/opt/pmd-bin-7.26.0`, symlinked `bin/pmd` into `~/.local/bin` (the plugin does **not** bundle the tool; the sensor shells out to `pmd`). Version matches the one CI installs and the one the sensor was verified against.
3. Installed habit-hooks **from this source tree** — `uv tool install "/workspace[java]"` — which built and installed `habit-hooks`, `habit-hooks-generic` and `habit-hooks-java` from the workspace and produced the four CLIs. Confirm: `habit-hooks --version` → `habit-hooks v1.1.0`.

### Example project end-to-end (`/tmp/habit-hooks-java-example`)

A git repo with `pom.xml`, `.habit-hooks/config.toml` (`plugins = ["java"]`), and four compiling Java files that deliberately carry the six smells:

| File | Smells (source) |
|------|-----------------|
| `Billing.java` | `too-many-parameters` (`pmd:ExcessiveParameterList`), `unused-import` ×3 (`pmd:UnnecessaryImport`), `unused-variable` (`pmd:UnusedLocalVariable`) |
| `OrderValidator.java` | `high-complexity` (`pmd:CyclomaticComplexity`) |
| `ReportBuilder.java` | `oversized-function` (`pmd:NcssCount`) |
| `FileReader.java` | `swallowed-exception` (`pmd:EmptyCatchBlock`) |

- Sources compile with `javac` (the smells are structural, not compile errors).
- `habit-sensors --all` → all six findings, each stamped `language: java` and `source: pmd:<rule>`.
- `habit-hooks --all` → coaches each smell with the catalogue guide; exits **1** (enforced findings).
- Default `habit-hooks` run (branch scope) and `--branch main` run work in the git repo.

### Behavioural seams the PR cares about

- A project's own ruleset wins over the bundled one (spec case writes a `src/main/resources/pmd/ruleset.xml` lowering the parameter threshold).
- A crashing PMD (unparseable file) fails the run with `incomplete-run`, never a false-clean — verified by the spec.
- Missing PMD → `pmd: command not found`, exit non-zero, no traceback (covered by both the plugin's unit test and, end-to-end, by the empty-pipe semantics of the core).

## Reviewer notes

- The `all` extra and release matrix now cover six packages; release env `pypi-java` must exist in GitHub for the publish job.
- PMD 7.26.0 is pinned in CI (exact download URL) and is the version the picocli/`-R` gotcha was verified against — a future PMD bump should re-run the spec cases.
- `NcssCount` dropping class-level violations is a deliberate scope choice (no catalogue smell for oversized classes).
