### PR TITLE
Four issues reported against 1.4.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 1.4.0rc3
+
+Reported by @imalliaras (#142) and @FrankRaiser (#140, #143). None of them is a
+Windows bug: all three reproduce on any platform, and were found there only
+because that is where these two were running.
+
+### Fixed
+
+- **A sensor no longer dies without a word when its tool has a lot to say.**
+  Node caps a captured stream at 1 MB unless told otherwise, and the eslint
+  sensor never told it otherwise: past that, the spawn came back with no exit
+  status, a truncated report and an empty stderr, and the sensor forwarded the
+  empty stderr. The whole notice was a command line. Around 100 files with
+  findings is enough to cross it, on any platform (#142). What a project tool's
+  run answered — how much of it there may be, whether it broke, and what to say
+  about it — is now one seam's question rather than each caller's, so the two
+  callers cannot answer it differently again. A complaint can no longer be empty.
+
+- **`--all` no longer scans what git ignores.** Every git-derived mode asks git
+  and so had never seen a build artifact; a whole-project run walked the
+  directory tree and measured everything it found. One project, two universes:
+  a real pnpm monorepo held 321 tracked `.ts`/`.tsx` files and 843 on disk, and
+  its owner had to hand-write `!**/dist/**` into `[files]` before a run was
+  usable (#142). A project git cannot answer for — outside a repository, on a
+  machine with no git, or one that is itself ignored by the repository around it
+  — still measures what is on disk, because a run that silently scans nothing is
+  worse than one that over-scans. A submodule's files leave the scope, as they
+  always had from every git-derived mode, and the run now says which submodule
+  rather than quietly measuring less.
+
+- **A scan that measured nothing says so.** A `[files]` that matches no file —
+  because it is too narrow, or because git ignores the tree it was written for —
+  used to render the clean guide over a run that had read nothing at all.
+
+- **A smell is coached once, not once per sensor that saw it.** Two sensors can
+  report one smell — eslint's `max-lines` and the line counter both mean
+  `oversized-file` — and the mapper printed a block per finding, so the same
+  ~200-word guide arrived twice (#140). Findings that resolve to the same guide
+  are now one finding. A sensor's own issue list is never thinned: two unused
+  variables declared on one line are still two.
+
+- **habit-hooks no longer reports its own tools as unused dependencies.** It
+  asks a project to install `eslint`, `knip`, `ts-morph`, `jscpd` and the two
+  `@typescript-eslint` packages, and then reported all of them as declared and
+  imported nowhere (#143). The shipped knip config overlooks them. A project
+  with its own knip config is unaffected, as it is for every other setting.
+
+- **A failing tool's own words are bounded within a line, not only across
+  lines.** The notice quoted back at most 20 lines and any number of bytes, and
+  `eslint -f json` is one line however many megabytes it holds — so a sensor
+  that died mid-report put the whole report into a coding agent's context. Both
+  ends of a long line now survive, with the middle named.
+
+- **A `[runners]` command nobody installed answers in one line.** Routing a smell
+  to an executable guide instead of a Markdown one, and naming a command that is
+  not there, printed a Python stack trace — the same first-contact mistake #114
+  answered everywhere else, in the one place that sweep did not reach.
+
+- **The knip sensor reports a column under the name the contract gives it.**
+  knip spells it `col`; every other sensor and `docs/sensor-interface.spec.md`
+  spell it `column`, so the position was invisible to anything asking by name.
+
 ## 1.4.0rc2
 
 Native Windows support. Reported by @FrankRaiser (#133) and @imalliaras (#134),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,130 @@ is a different question from which snoozes lapse), so the widening lives in
 replaces them wholesale. That is why `config.py` imports `Resolver` — the merge
 needs the override chain, and only `files` has a plugin-supplied default.
 
+### A whole-project scan measures what git keeps, never what is on disk (human-requested by Ivett, issue #142)
+
+`project_scan.files_in()` — `scope._every_file`'s only source — asks
+`git_listing.project_files` (`git ls-files --cached --others --exclude-standard`,
+so tracked **plus** brand-new-but-not-ignored) instead of walking `rglob("*")`.
+Before #142, `--all` was the one mode that never asked git, so it alone measured
+`dist/`, `.next/` and tool caches: a real monorepo enumerated 843 `.ts`/`.tsx`
+for the 321 it keeps, and its owner had to hand-write `!**/dist/**` into
+`[files]` to get a usable run. Every git-derived mode already skipped those, so
+this is what stops one project having two universes. The narrowings after it are
+unchanged — `_source_files` still drops what the work tree lost and still applies
+`[files]` — and discovery stays opt-in, so `config.files is None` returns `[]`
+before git is asked anything.
+
+Git's silence is never "nothing to scan" (the #81 rule): outside a repository,
+with no git installed, or on any failure at all, the empty answer falls back to
+the `rglob` walk. Over-scanning is a nuisance; scanning nothing reports a whole
+tree clean unread. That `or` is also why the whole-tree cases need no guard of
+their own — a project the surrounding repository ignores outright answers empty
+and falls back on its own.
+
+**`git_listing.ignores_directory` exists for the answer that is *partial*, not
+the one that is empty.** It gives git's list up when the repository above the
+project ignores the project directory. An outer repository can force-add one
+file under a path it ignores; git then lists that file and nothing else, and a
+partial list is the shape the `or` cannot see — it looks like a real answer, so
+the run measures one file and pronounces every other file clean without reading
+it. `--no-index` is what makes the question about the ignore rules rather than
+the index: by default `check-ignore` calls a directory holding anything tracked
+"not ignored", so without it the guard stands down for exactly that project.
+
+**Ask about the project by name, and only if it is not a repository root.** The
+question was `check-ignore --no-index --quiet .`, and both halves of that were
+wrong. A repository never ignores its own root, but `*` — the allow-list opening
+that a careful `.gitignore` very often has — matches the name `.` like any
+other, so a project reported *itself* ignored and threw away a perfectly good
+file list; #142 then silently did not apply to it. So `rev-parse
+--show-toplevel` settles the root case first. Below a root the rules really are
+consulted, and `.` there resolves against the *project's own* `.gitignore`
+rather than the one deciding about the project — hence the full path,
+`check-ignore --no-index --quiet -- <project_dir>`. Seven shapes were measured
+(root ordinary / root with `*` / clean subdir / ignored subdir / subdir with its
+own `*` / own repo inside an ignored tree / no repo) and only this pairing gets
+all seven right.
+
+The gates are in `tests/test_a_scan_skips_what_git_ignores.py` (the two `*`
+cases, one per half of the fix) and
+`test_one_force_tracked_file_never_becomes_an_ignored_projects_whole_scope`,
+which is the only test that fails when the guard is dropped altogether.
+Measured, because the tempting justification is wrong: forcing
+`ignores_directory` to `False` leaves **every spec case passing**, so "our own
+`.spec-runs/` would scan nothing" does not motivate the guard, and neither does
+`test_a_project_in_somebody_elses_ignored_tree_scans_everything`, which passes
+with the guard gone.
+
+A **submodule** is the one deliberate loss: `ls-files` names it as a single
+gitlink *directory*, never the files inside. Keeping it out is right — `git diff`
+does not descend into one either, so this makes `--all` agree with the modes it
+used to contradict, and the submodule gates itself in its own repository. But a
+scope that silently shrinks and then renders ✅ is the false clean this tool
+exists to stop, so `scope_notices.submodule_notices` names each one on stderr.
+It is advisory and leaves the exit code alone, matching every other scope notice
+(a run that scanned *nothing* still exits 0). `--file` is excluded because that
+path is one the caller typed rather than one git named; a directory given to it
+is already answered by `_named_file_notice`.
+
+**Ask the index what a submodule is, never the filesystem.** A submodule is a
+gitlink, which git records with mode `160000`, so `git ls-files --stage` answers
+exactly and `.gitmodules` never has to be parsed. `Path.is_dir()` cannot answer
+it: it follows symlinks, so a *tracked symlink to a directory* (mode `120000`)
+is indistinguishable from a gitlink — and a symlinked `node_modules` is pnpm's
+ordinary layout, so the filesystem question tells an everyday JavaScript project
+that its dependency tree is a submodule. Reaching for `is_symlink()` instead
+would still be the wrong question with a luckier answer.
+
+**And say it only about a submodule whose files the run wanted.** The claim is
+"your scan is smaller than you think", which is false where `[files]` excluded
+the directory regardless — the typescript plugin's own `!**/node_modules/**` is
+the case that proved it. `_held_source_this_run_wanted` lists what the submodule
+really holds (`git ls-files` inside it) and puts those paths through `[files]`;
+matching the *directory name* would silence every notice, because a source glob
+like `**/*.py` never matches a bare directory. `scope_notices` owns **both**
+halves of that judgement even though `git_listing` knows what a gitlink is and
+`scope` owns the narrowing: a notice right about one half and wrong about the
+other is worse than none, and neither of those modules can state the thing being
+claimed. `path_globs.matching` exists so it can ask the `[files]` question
+without importing `scope`, which is its own caller.
+
+The split follows the repo's existing precedents, in one direction throughout:
+`scope` → `project_scan` → `git_listing` → `git_command`. `project_scan.py`
+holds what a project *has* against `scope.py`'s what a run *measures*.
+`git_listing.py` is what git says about the **working tree as it stands** (which
+files, which ignored) against `git_history.py`'s what git **remembers** between
+revisions — `git_history` asks it only to widen a diff with untracked work.
+`git_command.py` is **how** any of it is spawned (cwd, UTF-8, empty stdin,
+`OSError` → `None`) against **what** is asked. All three moves were forced by the
+200-line `oversized-file` gate the dogfood run enforces, and each moved a whole
+concern rather than trimming prose.
+
+**Every empty scope says why it is empty**, and a `[files]` that is set and
+matched nothing was the last silent case. A project whose `.gitignore` covers
+its own source tree keeps no files git will name, so it scanned zero files and
+rendered ✅ — a run that *measured* nothing, indistinguishable from one that
+*found* nothing, which is the #88 class. `NOTHING_MATCHED_NOTICE` names both
+possible causes, because neither is visible from the other: `[files]` may be too
+narrow, or git may be ignoring the very tree it was written for.
+
+A **non-empty** scope that lost some files is deliberately left silent. Measured
+on a project with an ordinary `.gitignore`: eight `.py` files dropped, seven of
+them `.venv`, `node_modules` and `dist`. Naming them is noise, and finding them
+at all needs the disk walk this change exists to avoid — so the empty scope,
+where the loss is total and the run is worthless, is the case worth catching.
+
+Two things `git_command` settles for every caller above it. A non-zero exit
+yields **empty**, never the output — `rev-parse --abbrev-ref HEAD` in a
+repository with no commits exits 128 *and* prints `HEAD`, so trusting stdout
+would publish that as a branch name (`tests/test_git_command.py`). And
+`files_in`'s two branches must **sort** alike: the walk builds its own strings
+from `os.sep`, and `\` and `/` sort differently, so without `as_posix()` the
+same project comes back in one order from git and another from the walk. No
+caller ever sees a backslash — `scope._placed` normalises again through
+`project_paths` — so this is about the branches being interchangeable, not about
+a spelling escaping into a finding.
+
 ### A config's schema is `config_schema.py`; finding and merging it is `config.py` (human-requested by Ivett)
 
 `config_schema.py` answers what a config **is** and may **say**: the attrs types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -742,6 +742,52 @@ better than pinning it at all: nothing platform-specific is left to assert.
 
 ## Gotchas
 
+### Two agents running pytest in one checkout fail each other's tests
+
+Two suites keep their working state *inside the checkout* rather than in a
+per-test temp dir, so a second concurrent `uv run pytest` walks into the middle
+of the first one's run:
+
+- the spec harness runs every case in the shared `<repo>/.spec-runs/`
+  (`conftest.py::_case_root`), and
+- `tests/wheelhouse.py` builds the released wheels and installs them into
+  throwaway venvs, which `test_installed_wheel_smoke.py` and
+  `test_installed_plugin_packaging.py` then run.
+
+Both go red under concurrency and both pass on an unchanged re-run — 15 spec
+failures in one session, 6 packaging failures in another, none of them real. A
+**unit** failure in `tests/` is always real; a failure in either of those two is
+not evidence until it survives a re-run in a quiet tree. Give each agent its own
+worktree (`git worktree add ../habit-hooks-<task> -b <task> main`) when more than
+one will run the suite, and note that inside a worktree the jscpd gotcha below
+makes `uv run habit-hooks --all` prove nothing about duplication.
+
+### A throwaway git fixture names its directory, or it commits to THIS repo
+
+`GIT_CEILING_DIRECTORIES` is not the guard for a scratch script. It stops git
+walking *up* to find a repository — and a script whose working directory is
+already this checkout never needs it to. `git init` on an existing repository is
+a harmless re-init, so nothing refuses; the `git add -A` and `git commit` that
+follow land on the real thing. It has happened: 45 files of four agents'
+uncommitted work swept into a commit titled `init`, and the dogfood
+`.habit-hooks/config.toml` overwritten by the fixture's own.
+
+The shape that does it is a multi-line `bash` command where only the first line
+is guarded:
+
+    cd $SCRATCH/proj && git init -q && ...   # cd fails, the line is skipped
+    git add -A && git commit -m init         # no guard: runs HERE
+
+So: **every git command in a fixture spells `git -C <dir>`**, and a fixture
+never runs a bare `git` after a `cd`. A failed `cd` then targets nothing instead
+of targeting this repository. `git add -A` outside a `-C` is the specific thing
+to never write.
+
+Recovery, if it happens again: `git reset --mixed <the real HEAD>` keeps every
+change as a working-tree modification and loses nothing, because the accidental
+commit was `git add -A` and therefore captured everything. Then restore whatever
+the script overwrote from HEAD.
+
 ### A git-backed spec case without a ceiling can rewrite THIS repo
 
 The spec harness runs each case in `<repo>/.spec-runs/tmpXXXX/`, inside this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,88 @@ the repo's own 200-line `oversized-file` gate by it, which the dogfood step
 (`── smell (n issues) ──`, blank line, guide text). Format it anywhere else and
 a run's output drifts from a coached incomplete run's.
 
+### Findings that render the same guide are one finding (agent decision, issue #140)
+
+`merged_findings.merged()` is the third module across that same line: `mapper.run`
+folds findings together *before* `render_finding` sees any of them, so
+`rendering.py` still renders exactly one finding and knows nothing about this.
+Two sensors can see one smell (eslint's `max-lines` and generic's `line-count`
+both report `oversized-file`) and one sensor can report a smell many times over
+(jscpd emits a finding per clone), and the mapper prints one block per finding —
+so each of those was another copy of the same ~200-word guide.
+
+**The key is the smell AND the guide it resolves to, never the smell alone.** One
+guide printed twice is the whole waste being removed, so merging exactly what
+renders alike is correct by construction. Merging by smell alone is a
+*misrouting bug*: `high-complexity` routes to the python plugin's guide for a
+`.py` file and to generic's for a `.ts` one, and folding them together coaches a
+TypeScript file in Python (or silently drops a Python file's Python guidance,
+depending on plugin order). Keying on `language` instead fixes nothing, because
+`generic` declares none. The smell stays in the key for two reasons: a
+`[smells.<name>] guide` override can point two smells at one file and their
+banners still name them apart, and `rendering.severity_of` is per smell — keyed
+on the guide alone, a *suggested* finding could absorb an *enforced* one and
+lower the run's exit code. `merged` takes the resolution as a **callable**
+so it never learns about `Config` or `Resolver`; `rendering.resolve_guide` is
+public for that one caller, and the dependency stays one-way.
+
+Merging is the **mapper's**, never the sensors stage's: what a sensor emitted is
+the run's own record, read by `habit-snooze`, so a snooze key must not depend on
+who else saw the same file.
+
+**The merged finding's facts.** Issues concatenate in arrival order. A top-level
+key (`language`) is **first non-null** — the runner leaves it unset for
+`generic`, so a null must not out-rank a real answer. A smell-level `details`
+key is kept when only one finding states it (`line-count`'s `maxAllowed`) and
+**dropped when two state it differently**: jscpd's `lines`/`tokens` describe one
+clone pair, and publishing the first pair's numbers as the whole finding's would
+teach a wrong number where a missing key renders as nothing. No shipped guide
+reads finding-level `details` — every reference in `guides/**` is a per-issue
+value inside a loop over `issues` — but `docs/sensor-interface.spec.md` and
+`docs/habit-mapper.spec.md` both teach plugin authors to read it, and
+`render_runner` hands a fix runner the whole finding.
+
+**Deduplication is across findings only, never within one.** A sensor's own issue
+list is authoritative: it meant the seven long functions it reported. Three
+shipped sensors (`pmd`, `phpmd`, `comment`) key by file, give a line and give
+**no column**, so two of their issues on one line — `int a = 1, b = 2;`,
+`$a = 1; $b = 2;`, a block and a line comment — are one place to any identity
+built from the place alone, and only the tool's `message` tells them apart. #140
+is about two *sensors* reporting one thing, so each finding's own list is kept
+whole and only what an earlier finding already named is dropped.
+
+An issue is identified by its `key` and **the place it names**, and by nothing
+either tool said in its own voice: `source` and `message` disagree precisely
+because they are two tools. `PLACE_FIELDS` is `file`, `line`, `column`,
+`startLine`, `endLine` — the contract's own location fields plus the range
+`duplicated-code` spells instead of a line. Every one is load-bearing and has a
+test that dies without it. Widening the identity only ever keeps issues apart,
+which is the safe direction; narrowing it silently deletes findings.
+
+**Known consequence: `duplicated-code` loses its pairing.** jscpd emits a finding
+per clone pair, so three pairs merge into one six-entry list and which occurrence
+matched which is no longer visible. Accepted deliberately — the guide repeated
+per pair was the #140 complaint and the token saving is large, and arrival order
+keeps each pair adjacent in the list. Restoring the pairing means teaching the
+guide to group, not un-merging the finding.
+
+**A fix runner sees the merged finding, not the sensor's.** `render_runner` runs
+once per finding, so a runner judging what it is handed judges more issues than
+any one sensor reported — and its exit code sets whether the run blocks. Two
+`oversized-file` findings of one issue each, under a runner that fails only a
+single-issue finding, exit 1 before merging and 0 after. That is the intended
+semantics (one guide, one judgement), but it is consumer-visible, so a runner
+must be written against a whole smell rather than a single sensor's report.
+
+The other half is at the sensor: `eslint.cjs`'s `FILE_LEVEL_SMELLS` drops the
+position from a smell whose guide lists files rather than lines
+(`includes/file_level_issues.md`), because `max-lines` reports at the first line
+past the limit and `line-count` names no line at all — disagreeing there is what
+stopped the two being recognised as one observation. `parse-error` is file-level
+too and is deliberately **not** in that set: its position is where parsing really
+failed, and nothing else reports it about a file eslint can read. The keys stay,
+`null`, so an eslint issue's `details` keep one shape.
+
 ### What a failure *says* is `part_output.py`; how much of it is `diagnosis.py` (agent decision)
 
 `part_output.py` decides what a finished part's output means — which exit codes

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -444,7 +444,7 @@ mapping, config validation) are resolved and recorded above / in
   PHP-specific to say about an unused local.
 - **`tests/test_catalogue_coverage.py` is the gate that stops the gap
   reopening.** It routes every smell in `catalogue.DEFAULT_SEVERITY` through the
-  real `rendering._resolve_guide` against the full installed plugin set and fails
+  real `rendering.resolve_guide` against the full installed plugin set and fails
   if any renders `uncoached.md`. "Somebody notices missing coaching" is now a red
   build, not a bug report.
 - **`unused-export` stays `enforced` — deliberately, and this records why.** The

--- a/docs/habit-sensors.spec.md
+++ b/docs/habit-sensors.spec.md
@@ -1254,12 +1254,17 @@ command = "cat ${dir}/clean.json"
 { "compilerOptions": { "strict": true } }
 ```
 
+This project's `[files]` names `**/*.py` and it has no Python in it, so the run
+also says it measured nothing — a scan that found no files must never be
+mistaken for a scan that found no problems.
+
 ```bash
 habit-sensors --all 2>&1 >/dev/null
 ```
 
 🖥️ ✅
 ```text
+habit-sensors: nothing matched [files] — check it in .habit-hooks/config.toml, and whether git ignores the paths you expected; nothing scanned
 habit-sensors: detected typescript; the typescript plugin is installed but not enabled — add "typescript" to `plugins` in .habit-hooks/config.toml
 ```
 
@@ -1304,13 +1309,23 @@ comes from the `[scope]` config.
 
 | Flag | Scope |
 |------|-------|
-| `--all` | every file |
+| `--all` | every file the project keeps |
 | `--file <path>` | a single file |
 | `--branch [base]` | changed since this branch left `base` (default `scope.branchBase`) |
 | `--last <n>` | changed in the last `n` commits |
 | `--since <ref>` | changed since a commit |
 | `--config <path>` | use an explicit config file |
 | (none) | `scope.changedOnly` → uncommitted; else `scope.autoBranchOffMain` → vs base unless on `scope.mainBranch`; else all |
+
+"Every file the project keeps" means what git keeps: everything tracked, plus
+everything just written that is not ignored. So `dist/`, `.next/` and a tool
+cache are out of `--all` for the same reason they were always out of `--last 1`
+— no mode measures a file another mode cannot see. A submodule is another
+repository and gates itself, so its files are not scanned here either; the run
+names each one it left out on stderr, so a scan that shrank never passes for a
+scan that found nothing wrong. Outside a git repository, or with no git
+installed, `--all` falls back to walking the directory tree, because a run that
+scanned nothing must never look clean.
 
 A git-mode flag run outside a git repository errors; the config-derived modes
 fall back to scanning every file instead. A ref a *real* repository does not have
@@ -1513,6 +1528,63 @@ habit-sensors --all
 🚨
 ```text
 habit-sensors: no [files] are configured — name what to scan in .habit-hooks/config.toml; nothing scanned
+```
+
+### A whole-project scan skips what git ignores
+
+`--all` measures what the project keeps, so a build artifact it told git to
+forget is not scanned — even when `[files]` is wide enough to match it. Coaching
+a generated file helps nobody: nobody edits it, and the fix is in whatever
+generated it (#142).
+
+This case builds its own repository, for the reason the next section explains in
+full: without `git init` and a ceiling, git answers about habit-hooks itself.
+
+✏️GIT_CEILING_DIRECTORIES
+```text
+$PWD/..
+```
+
+📄.habit-hooks/config.toml
+```toml
+plugins = ["generic"]
+files   = ["**/*.txt"]
+```
+
+📄.gitignore
+```text
+dist/
+```
+
+📄src/a.txt
+```text
+a
+```
+
+📄dist/built.txt
+```text
+built
+```
+
+```bash
+git init -q -b main . &&
+  git config user.email spec@example.com &&
+  git config user.name "Spec Runner" &&
+  git config commit.gpgsign false &&
+  git add src .gitignore &&
+  git commit -q -m baseline
+```
+
+`dist/built.txt` is on disk and matches `[files]`, so only git's opinion keeps it
+out of the scan.
+
+```bash
+habit-sensors --all | jq -c '[.[].issues[].key]'
+```
+
+🖥️ ✅
+```json
+["src/a.txt"]
 ```
 
 ### Git-derived scopes

--- a/docs/smell-vocabulary.md
+++ b/docs/smell-vocabulary.md
@@ -84,7 +84,7 @@ map-block), and the smell key each maps to.
 | `knip:classMembers`, `knip:enumMembers`           | `unused-class-member`       |
 | `knip:files`                                      | `unused-file`               |
 | `knip:exports`, `knip:types`, `knip:nsExports`, `knip:nsTypes` | `unused-export` |
-| `knip:dependencies`                               | `unused-dependency`         |
+| `knip:dependencies`, `knip:devDependencies`, `knip:optionalPeerDependencies` | `unused-dependency` |
 | `knip:production:*`                               | `test-only-dead-code`       |
 | `eslint:fatal`                                    | `parse-error`               |
 

--- a/plugins/generic/pyproject.toml
+++ b/plugins/generic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks-generic"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "The generic (language-agnostic) Habit Hooks plugin"
 readme = "README.md"
 license = "MIT"

--- a/plugins/java/pyproject.toml
+++ b/plugins/java/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks-java"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "The Java Habit Hooks plugin"
 readme = "README.md"
 license = "MIT"

--- a/plugins/php/pyproject.toml
+++ b/plugins/php/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks-php"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "The PHP Habit Hooks plugin"
 readme = "README.md"
 license = "MIT"

--- a/plugins/python/pyproject.toml
+++ b/plugins/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks-python"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "The Python Habit Hooks plugin"
 readme = "README.md"
 license = "MIT"

--- a/plugins/typescript/pyproject.toml
+++ b/plugins/typescript/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks-typescript"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "The TypeScript Habit Hooks plugin"
 readme = "README.md"
 license = "MIT"

--- a/plugins/typescript/src/habit_hooks_typescript/knip.json
+++ b/plugins/typescript/src/habit_hooks_typescript/knip.json
@@ -9,5 +9,12 @@
     "tests/**"
   ],
   "project": ["src/**/*.ts!", "src/**/*.tsx!"],
-  "ignore": ["dist/**"]
+  "ignore": ["dist/**"],
+  "ignoreDependencies": [
+    "eslint",
+    "ts-morph",
+    "@typescript-eslint/parser",
+    "@typescript-eslint/eslint-plugin",
+    "jscpd"
+  ]
 }

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
@@ -61,12 +61,6 @@ const UNSEPARATED_ARGV =
   "eslint sensor: its argv must spell '--' between the sensor's arguments and " +
   "the scoped files — see sensors/eslint.toml\n";
 
-// eslint takes the tool's usual exit code for findings (1) and reserves
-// everything above it for its own breakage; a signal leaves no code at all.
-function broke(result) {
-  return result.status === null || result.status > 1;
-}
-
 // Only eslint can say whether the project has a config, because its lookup runs
 // from each linted FILE's directory (eslint 10 `lib/config/config-loader.js`) —
 // a config below the directory habit-hooks was invoked in is eslint's answer
@@ -77,7 +71,7 @@ function broke(result) {
 // ever change, a config-less project fails loudly rather than being mis-linted
 // quietly, which is the direction to be wrong in.
 function wantedAConfig(result) {
-  return broke(result) && (result.stderr || "").includes(NO_CONFIG_FOUND);
+  return projectTool.broke(result) && (result.stderr || "").includes(NO_CONFIG_FOUND);
 }
 
 // `--no-warn-ignored` stops the commonest rule-less message being raised at all.
@@ -169,8 +163,8 @@ function main() {
   const files = argv.slice(boundary + 1).filter((file) => LINTABLE.test(file));
   if (files.length === 0) return emit([]);
   const result = lint(argv.slice(0, boundary), files);
-  if (broke(result) || result.stdout.trim() === "") {
-    return refuse(result.stderr || "");
+  if (projectTool.broke(result) || result.stdout.trim() === "") {
+    return refuse(projectTool.complaint(ESLINT, result));
   }
   return emit(findings(JSON.parse(result.stdout)));
 }

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
@@ -181,10 +181,10 @@ function main() {
   const files = argv.slice(boundary + 1).filter((file) => LINTABLE.test(file));
   if (files.length === 0) return emit([]);
   const result = lint(argv.slice(0, boundary), files);
-  if (projectTool.broke(result) || result.stdout.trim() === "") {
-    return refuse(projectTool.complaint(ESLINT, result));
-  }
-  return emit(findings(JSON.parse(result.stdout)));
+  if (projectTool.broke(result)) return refuse(projectTool.complaint(ESLINT, result));
+  const report = projectTool.readJsonReport(result.stdout);
+  if (report === null) return refuse(projectTool.unreadableOutput(ESLINT, result));
+  return emit(findings(report));
 }
 
 // Not process.exit(): stdout is a pipe under the runner and writes to it are

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/eslint.cjs
@@ -42,6 +42,19 @@ const SMELL_BY_RULE = new Map(
 // what this smell exists to report, so it is the one kept.
 const PARSE_ERROR = "parse-error";
 
+// A smell about the FILE, whose guide lists files rather than lines
+// (`includes/file_level_issues.md`). eslint still positions its message —
+// `max-lines` reports at the first line past the limit — but that is where its
+// counter tripped, not where the problem is, and carrying it is what stopped
+// the same file being recognised as one observation when the generic
+// `line-count` sensor reported the same smell about it (#140).
+//
+// `parse-error` is file-level too and is deliberately absent: its position is
+// where parsing actually failed, and no other sensor reports it about a file
+// eslint can read, so there is nothing to reconcile and real information to
+// lose.
+const FILE_LEVEL_SMELLS = new Set(["oversized-file"]);
+
 // The config this plugin ships, beside the sensors directory it runs from.
 const SHIPPED_CONFIG = path.join(__dirname, "..", "eslint.config.mjs");
 
@@ -102,13 +115,18 @@ function isReportable(message) {
 }
 
 function reported(file, message) {
+  const smell = smellOf(message);
+  // The keys stay whichever way, null where there is no position to give: every
+  // eslint issue's details carry them, and a key that disappears reads
+  // downstream as a different shape rather than as a missing value.
+  const positioned = !FILE_LEVEL_SMELLS.has(smell);
   return {
-    smell: smellOf(message),
+    smell,
     key: file,
     details: {
       file,
-      line: message.line ?? null,
-      column: message.column ?? null,
+      line: positioned ? (message.line ?? null) : null,
+      column: positioned ? (message.column ?? null) : null,
       message: message.message,
       source: `eslint:${message.ruleId ?? "fatal"}`,
     },

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
@@ -77,17 +77,7 @@ function isTestFile(file) {
 // Windows as a `.cmd` shim, which Node refuses to spawn and a bare name never
 // reaches, and it answers there for a knip nobody installed too.
 function runKnip(args) {
-  return projectTool.run(KNIP, ["--reporter", "json", ...args], {
-    maxBuffer: 64 * 1024 * 1024,
-  });
-}
-
-function knipCrashed(result) {
-  return result.error != null || result.status === null || result.status > 1;
-}
-
-function knipFailure(result) {
-  return result.stderr || String(result.error);
+  return projectTool.run(KNIP, ["--reporter", "json", ...args]);
 }
 
 // knip 5's JSON emits per-file arrays for most issue types but object maps for
@@ -253,21 +243,42 @@ function report(result) {
   return JSON.parse(result.stdout);
 }
 
+// A run there is no report to read: broken, or a knip that exited cleanly
+// having printed nothing at all. `JSON.parse("")` is a SyntaxError, so that
+// second case reached the runner as a Node traceback rather than a diagnosis —
+// #142 one branch over. `eslint.cjs` asks the same question inline before it
+// parses, and both answer it in the seam's words.
+//
+// It stays out of `project_tool`: whether stdout should hold a JSON report is
+// the caller's business (`--reporter json` is knip's flag, not the spawner's),
+// where whether the run broke is the spawn's.
+//
+// The second half answers safely whatever it is handed, rather than leaning on
+// the first to have caught it: a spawn that never started has no `stdout`
+// string to trim. `broke` does catch every one of those — it reads `error` and
+// `status` and never a stream — so nothing can reach the `typeof` today, and
+// it is here for the same reason `project_tool.broke` keeps its own
+// unreachable `error` clause. Being total is what stops the order of the two
+// mattering, which no test could have told us about.
+function noReportFrom(result) {
+  if (projectTool.broke(result)) return true;
+  return typeof result.stdout !== "string" || result.stdout.trim() === "";
+}
+
+function refuse(complaint) {
+  process.stderr.write(complaint);
+  return 2;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const config = configInForce(args);
   const base = runKnip([...config.args, ...args]);
-  if (knipCrashed(base)) {
-    process.stderr.write(knipFailure(base));
-    return 2;
-  }
+  if (noReportFrom(base)) return refuse(projectTool.complaint(KNIP, base));
   let production = null;
   if (configMarksProduction(config.file)) {
     const pass = runKnip([...config.args, ...args, "--production"]);
-    if (knipCrashed(pass)) {
-      process.stderr.write(knipFailure(pass));
-      return 2;
-    }
+    if (noReportFrom(pass)) return refuse(projectTool.complaint(KNIP, pass));
     production = report(pass);
   }
   process.stdout.write(JSON.stringify(findings(report(base), production)));

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
@@ -63,6 +63,28 @@ const KNIP = "knip";
 const MANIFEST = "package.json";
 
 // The config this plugin ships, beside the sensors directory it runs from.
+//
+// Its `ignoreDependencies` overlooks the packages habit-hooks asked the project
+// to install: unimported, because habit-hooks is what uses them, knip called
+// every one dead weight and told the project to delete the tools it had just
+// been told to install (#143). The note lives here because JSON carries no
+// comment — `configMarksProduction` reads that file with `JSON.parse`.
+//
+// *Which* packages is deliberately not restated here.
+// `tests/test_the_shipped_knip_config_ignores_what_we_asked_for.py` derives
+// them from every plugin's declarations and fails on a list that gains a name
+// we never asked for or drops one we did — which a plugin gaining a
+// `node-module` detector will meet, and this paragraph never would.
+//
+// The trade the gate cannot see: three of those names are ours only sometimes.
+// jscpd is our footprint while the generic plugin is enabled, and the two
+// `@typescript-eslint` packages only while the project has no eslint config of
+// its own, since that is the only time the shipped one runs. No static config
+// can ask either question, so a project with its own eslint config that
+// abandons `@typescript-eslint/parser` is never told. Taken knowingly: the
+// suppression is exact rather than by prefix (`@typescript-eslint/utils` is
+// still reported), and missing one package beats telling every consumer to
+// uninstall what they just installed.
 const SHIPPED_CONFIG = path.join(__dirname, "..", "knip.json");
 
 // A file the --production pass must never call dead, because that pass ignores
@@ -124,7 +146,12 @@ function issueFrom(row, source) {
   const details = { file: row.file, source };
   if (row.name !== undefined) details.name = row.name;
   if (row.line !== undefined) details.line = row.line;
-  if (row.col !== undefined) details.col = row.col;
+  // knip spells it `col`; the sensor contract (docs/sensor-interface.spec.md)
+  // spells it `column`, as every other sensor does. Translating the tool's
+  // vocabulary is this sensor's job, and a field name is vocabulary too —
+  // forwarded raw, the position was invisible to everything downstream that
+  // asks for it by name.
+  if (row.col !== undefined) details.column = row.col;
   return { key: row.name ?? row.file, details };
 }
 

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/knip.cjs
@@ -266,30 +266,20 @@ function configMarksProduction(file) {
   );
 }
 
-function report(result) {
-  return JSON.parse(result.stdout);
-}
-
-// A run there is no report to read: broken, or a knip that exited cleanly
-// having printed nothing at all. `JSON.parse("")` is a SyntaxError, so that
-// second case reached the runner as a Node traceback rather than a diagnosis —
-// #142 one branch over. `eslint.cjs` asks the same question inline before it
-// parses, and both answer it in the seam's words.
-//
-// It stays out of `project_tool`: whether stdout should hold a JSON report is
-// the caller's business (`--reporter json` is knip's flag, not the spawner's),
-// where whether the run broke is the spawn's.
-//
-// The second half answers safely whatever it is handed, rather than leaning on
-// the first to have caught it: a spawn that never started has no `stdout`
-// string to trim. `broke` does catch every one of those — it reads `error` and
-// `status` and never a stream — so nothing can reach the `typeof` today, and
-// it is here for the same reason `project_tool.broke` keeps its own
-// unreachable `error` clause. Being total is what stops the order of the two
-// mattering, which no test could have told us about.
-function noReportFrom(result) {
-  if (projectTool.broke(result)) return true;
-  return typeof result.stdout !== "string" || result.stdout.trim() === "";
+// One knip pass: what it reported, or the sentence saying why there is nothing
+// to report. Exactly one of the two is set, and both answers come from the seam
+// so this sensor and `eslint.cjs` cannot drift into saying different things
+// about the same failure — which is what #142 was.
+function knipPass(args) {
+  const result = runKnip(args);
+  if (projectTool.broke(result)) {
+    return { complaint: projectTool.complaint(KNIP, result) };
+  }
+  const report = projectTool.readJsonReport(result.stdout);
+  if (report === null) {
+    return { complaint: projectTool.unreadableOutput(KNIP, result) };
+  }
+  return { report };
 }
 
 function refuse(complaint) {
@@ -300,15 +290,15 @@ function refuse(complaint) {
 function main() {
   const args = process.argv.slice(2);
   const config = configInForce(args);
-  const base = runKnip([...config.args, ...args]);
-  if (noReportFrom(base)) return refuse(projectTool.complaint(KNIP, base));
+  const base = knipPass([...config.args, ...args]);
+  if (base.complaint) return refuse(base.complaint);
   let production = null;
   if (configMarksProduction(config.file)) {
-    const pass = runKnip([...config.args, ...args, "--production"]);
-    if (noReportFrom(pass)) return refuse(projectTool.complaint(KNIP, pass));
-    production = report(pass);
+    const second = knipPass([...config.args, ...args, "--production"]);
+    if (second.complaint) return refuse(second.complaint);
+    production = second.report;
   }
-  process.stdout.write(JSON.stringify(findings(report(base), production)));
+  process.stdout.write(JSON.stringify(findings(base.report, production)));
   return 0;
 }
 

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/project_tool.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/project_tool.cjs
@@ -75,14 +75,73 @@ function notInstalled(tool) {
   };
 }
 
-// What `tool` printed for `args`, as `spawnSync` reports it.
-function run(tool, args, options = {}) {
+// No ceiling on what a tool may print. `spawnSync` caps each captured stream at
+// 1 MB unless told otherwise, and answers a tool that prints more with ENOBUFS:
+// a truncated stdout, a `null` status, and an error the caller has to notice.
+// Forty files of ordinary lint findings cross that, and the sensor that ran the
+// tool is then left with nothing it can parse (#142).
+//
+// The 1 MB was never a decision, only the default nobody overrode. Every other
+// place habit-hooks reads a tool's output is unbounded — the plugins' five
+// Python helpers all capture with `subprocess.run`, the core drains its pipes
+// with `Popen.communicate()`, and `comment.cjs` holds its whole ts-morph result
+// in memory — so lifting it is what makes the Node helpers behave like the rest
+// of the tool rather than a special case.
+const NO_CEILING = Infinity;
+
+// What `tool` printed for `args`, as `spawnSync` reports it. The spawn takes no
+// options from the caller: there is one right answer to each of these for every
+// tool this seam runs, and a caller free to override them is a caller free to
+// put the 1 MB ceiling back, or to ask for a Buffer, which `complaint` would
+// then read as a tool that said nothing at all.
+function run(tool, args) {
   const script = entryScript(tool, process.cwd());
   if (script === null) return notInstalled(tool);
   return spawnSync(process.execPath, [script, ...args], {
     encoding: "utf8",
-    ...options,
+    maxBuffer: NO_CEILING,
   });
 }
 
-module.exports = { run };
+// The run produced no answer worth reading. Both tools this seam runs exit 1
+// for "I found something to report" — the commonest successful run there is —
+// so breakage starts above it. A `null` status is a run that never reached an
+// exit at all: killed by a signal, or refused before it began, which sets
+// `error` as well.
+function broke(result) {
+  return result.error != null || result.status === null || result.status > 1;
+}
+
+function spoke(output) {
+  return typeof output === "string" && output.trim() !== "";
+}
+
+function howItEnded(result) {
+  if (result.signal != null) return `killed by ${result.signal}`;
+  return `exited ${result.status}`;
+}
+
+// Why the run is unusable, in words a reader can act on — never an empty
+// string, which is the bug this whole seam exists to make impossible (#142),
+// and never more than a sentence unless the tool itself wrote one.
+//
+// Only two things can be the complaint. The tool's own words, wherever it got
+// any out, because a tool that diagnosed itself is the one thing a reader can
+// act on; every tool this seam runs writes them to stderr. Otherwise this seam
+// speaks for it, and then it must say WHICH tool — `spawnSync <path> ENOBUFS`
+// names the node that was spawned, never the tool that failed. Blank stderr is
+// not words: whitespace forwarded verbatim is the empty complaint again.
+//
+// What the tool half-printed to *stdout* is never either. It is a report cut
+// off mid-write, not a diagnosis: an OOM-killed eslint hands back the first few
+// megabytes of a JSON array, which says nothing about why it died and buries the
+// one sentence that would. `sensors/diagnosis.py` bounds what any notice carries,
+// so the cost is capped either way — but a reader would still be given a
+// truncated report where a reason belongs.
+function complaint(tool, result) {
+  if (spoke(result.stderr)) return result.stderr;
+  if (result.error != null) return `${tool}: ${result.error.message}\n`;
+  return `${tool}: ${howItEnded(result)} without a word of its own\n`;
+}
+
+module.exports = { run, broke, complaint };

--- a/plugins/typescript/src/habit_hooks_typescript/sensors/project_tool.cjs
+++ b/plugins/typescript/src/habit_hooks_typescript/sensors/project_tool.cjs
@@ -139,9 +139,48 @@ function howItEnded(result) {
 // so the cost is capped either way — but a reader would still be given a
 // truncated report where a reason belongs.
 function complaint(tool, result) {
-  if (spoke(result.stderr)) return result.stderr;
-  if (result.error != null) return `${tool}: ${result.error.message}\n`;
-  return `${tool}: ${howItEnded(result)} without a word of its own\n`;
+  return said(tool, result, `${howItEnded(result)} without a word of its own`);
 }
 
-module.exports = { run, broke, complaint };
+// The tool's own words if it got any out, and ours named for it if not.
+function said(tool, result, ours) {
+  if (spoke(result.stderr)) return result.stderr;
+  if (result.error != null) return `${tool}: ${result.error.message}\n`;
+  return `${tool}: ${ours}\n`;
+}
+
+// What to say when a run this seam calls FINE still left nothing to work with.
+// A tool that exited 0 or 1 has reported, as far as the spawn can tell, and
+// only its caller can find out that what it printed is not readable.
+//
+// Windows is what makes that a real failure rather than a tidy-up. It has no
+// signals: `process.kill` there is `TerminateProcess`, so a tool cut down
+// mid-report leaves an ordinary exit 1 — the same code eslint and knip use for
+// "I found something to report" — and its half-written array then reaches
+// `JSON.parse` as an unhandled `SyntaxError`. That is #142's own class one
+// branch further along, and the reason it is answered here rather than in
+// either caller.
+//
+// A tool that printed nothing at all gets the ordinary complaint: "without a
+// word of its own" is true of it, and false of one that flushed half a
+// megabyte before it died.
+function unreadableOutput(tool, result) {
+  if (!spoke(result.stdout)) return complaint(tool, result);
+  const ours = `${howItEnded(result)}, and what it printed is not a report this sensor can read`;
+  return said(tool, result, ours);
+}
+
+// The JSON a tool printed, or null when there is nothing there this sensor can
+// read — empty, cut short, or not a string at all. `JSON.parse` throwing is the
+// one failure a sensor must never let escape: the runner needs a sentence, and
+// a stack trace is the non-answer this whole seam exists to stop.
+function readJsonReport(stdout) {
+  if (typeof stdout !== "string") return null;
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { run, broke, complaint, unreadableOutput, readJsonReport };

--- a/plugins/typescript/tests/eslint_project.py
+++ b/plugins/typescript/tests/eslint_project.py
@@ -69,8 +69,16 @@ def run(project: Path, argv: list[str]) -> subprocess.CompletedProcess[str]:
     )
 
 
-def messages(project: Path, config: Path) -> list[dict]:
-    """What eslint says about the project's one file under ``config``."""
+def report(
+    project: Path,
+    files: tuple[str, ...] = ("src/repository.ts",),
+    config: Path = SHIPPED_CONFIG,
+) -> str:
+    """What eslint itself prints about ``files`` under ``config``, whole.
+
+    The sensor's own answer measured against this one is how a suite asks
+    whether anything was lost on the way back from the tool.
+    """
     result = run(
         project,
         [
@@ -81,11 +89,16 @@ def messages(project: Path, config: Path) -> list[dict]:
             "--no-warn-ignored",
             "--config",
             str(config),
-            "src/repository.ts",
+            *files,
         ],
     )
     assert result.stdout, result.stderr
-    return json.loads(result.stdout)[0]["messages"]
+    return result.stdout
+
+
+def messages(project: Path, config: Path) -> list[dict]:
+    """What eslint says about the project's one file under ``config``."""
+    return json.loads(report(project, config=config))[0]["messages"]
 
 
 def sensor_argv(

--- a/plugins/typescript/tests/node_tool_stub.py
+++ b/plugins/typescript/tests/node_tool_stub.py
@@ -34,18 +34,27 @@ process.stdout.write(fs.readFileSync(path.join(installed, "{report}"), "utf8"));
 """
 
 
-def install(project: Path, tool: str, prints: str) -> Path:
-    """``tool`` installed in ``project``, printing ``prints`` whatever it is asked."""
+def install_script(project: Path, tool: str, cli: str) -> Path:
+    """``tool`` installed in ``project`` as a package whose CLI is ``cli``.
+
+    Where the tool's own behaviour is the subject — a tool that fails, or that
+    outprints the buffer capturing it — the suite writes the CLI itself rather
+    than recording what it was asked.
+    """
     package = project / "node_modules" / tool
     (package / "bin").mkdir(parents=True)
     (package / "package.json").write_text(
         json.dumps({"name": tool, "version": "0.0.0", "bin": {tool: f"bin/{tool}.js"}}),
         encoding="utf-8",
     )
+    (package / "bin" / f"{tool}.js").write_text(cli, encoding="utf-8")
+    return package
+
+
+def install(project: Path, tool: str, prints: str) -> Path:
+    """``tool`` installed in ``project``, printing ``prints`` whatever it is asked."""
+    package = install_script(project, tool, RECORDER.format(log=ARGV_LOG, report=REPORT))
     (package / REPORT).write_text(prints, encoding="utf-8")
-    (package / "bin" / f"{tool}.js").write_text(
-        RECORDER.format(log=ARGV_LOG, report=REPORT), encoding="utf-8"
-    )
     return package
 
 

--- a/plugins/typescript/tests/project_tool_probe.py
+++ b/plugins/typescript/tests/project_tool_probe.py
@@ -40,6 +40,8 @@ process.stdout.write(
     broke: projectTool.broke(result),
     complaint: projectTool.complaint(tool, result),
     printed: (result.stdout || "").length,
+    status: result.status ?? null,
+    signal: result.signal ?? null,
   }),
 );
 """

--- a/plugins/typescript/tests/project_tool_probe.py
+++ b/plugins/typescript/tests/project_tool_probe.py
@@ -1,0 +1,89 @@
+"""Asking ``sensors/project_tool.cjs`` what it makes of a tool's run.
+
+The seam is a CommonJS module with no CLI of its own, so a case reaches it
+through a driver script that requires it, hands it one run and prints its two
+answers — whether the run broke, and the complaint it earned.
+
+The driver takes the run either way round. Given only a tool name it really
+spawns one, which is how a stub's exit code, signal and output become the
+seam's input. Given a run *described* to it as JSON it spawns nothing: with no
+ceiling on what a tool may print, a spawn that never completed cannot be
+provoked through this seam any more, and describing one is the only way left to
+reach the branches that answer for it — quicker, too, than arranging a real
+failure for a question that is only about the words.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from node_tool_stub import install_script
+
+SEAM = (
+    Path(__file__).parents[1]
+    / "src"
+    / "habit_hooks_typescript"
+    / "sensors"
+    / "project_tool.cjs"
+)
+
+# The paths arrive as arguments so this stays a constant with nothing spliced
+# into it: a JavaScript object literal and Python's own formatting do not mix.
+DRIVER = """const [seam, tool, described] = process.argv.slice(2);
+const projectTool = require(seam);
+const result =
+  described === undefined ? projectTool.run(tool, []) : JSON.parse(described);
+process.stdout.write(
+  JSON.stringify({
+    broke: projectTool.broke(result),
+    complaint: projectTool.complaint(tool, result),
+    printed: (result.stdout || "").length,
+  }),
+);
+"""
+
+
+def run(argv: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def a_project_whose_tool(tmp_path: Path, tool: str, cli: str) -> Path:
+    """A project holding one installed tool, whose CLI is ``cli``."""
+    project = tmp_path / tool
+    project.mkdir()
+    (project / "package.json").write_text('{"name": "demo"}', encoding="utf-8")
+    install_script(project, tool, cli)
+    return project
+
+
+def _driver(directory: Path) -> Path:
+    driver = directory / "seam-driver.cjs"
+    driver.write_text(DRIVER, encoding="utf-8")
+    return driver
+
+
+def _answer(argv: list[str], cwd: Path) -> dict:
+    result = run(["node", *argv], cwd)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def ask_the_seam(project: Path, tool: str) -> dict:
+    """What the seam makes of really running ``tool`` in ``project``."""
+    return _answer([str(_driver(project.parent)), str(SEAM), tool], project)
+
+
+def judge(tmp_path: Path, tool: str, described: dict) -> dict:
+    """What the seam makes of a run described to it, with nothing spawned."""
+    return _answer(
+        [str(_driver(tmp_path)), str(SEAM), tool, json.dumps(described)], tmp_path
+    )

--- a/plugins/typescript/tests/test_a_broken_tool_is_never_silent.py
+++ b/plugins/typescript/tests/test_a_broken_tool_is_never_silent.py
@@ -1,0 +1,187 @@
+"""A tool that failed always gets a sentence saying so — and only a sentence.
+
+An empty complaint is #142. ``spawnSync`` answers a stdout over its buffer with
+ENOBUFS, a ``null`` status and a *blank* stderr; the eslint sensor forwarded the
+blank, so the whole notice a reader got was the sensor's own command line —
+told that a sensor failed, and never what failed about it.
+
+So the seam both Node sensors run their tool through
+(``sensors/project_tool.cjs``) owns two questions neither caller may answer for
+itself: whether the run broke, and what to say about it. The words are the
+tool's own wherever the tool has any, because a tool that diagnosed itself is
+the thing a reader can act on; where it has none the seam speaks for it, and
+then it must say WHICH tool — ``spawnSync <path to node> ENOBUFS`` names the
+runtime, which is never the tool that failed.
+
+The other half is that a complaint stays *short*. What a tool half-printed to
+stdout is a cut-off report, not a diagnosis, and a sensor's whole stderr goes
+into a reading agent's context: ``sensors/diagnosis.py`` trims a long one by
+LINES, which does nothing at all to the single line ``eslint -f json`` emits.
+
+``project_tool_probe`` is how the seam is asked; what it is asked about is
+here. That its two callers really ask is
+``test_both_node_sensors_refuse_alike.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_tool_probe import a_project_whose_tool, ask_the_seam, judge
+
+SAYS_NOTHING = "process.exit(2);\n"
+COMPLAINS = 'process.stderr.write("knip.json: line 3 is nonsense\\n");\nprocess.exit(2);\n'
+
+# Comfortably past a pipe's own 64KB buffer, so the report really is in flight
+# rather than sitting in the tool. Nothing here needs the megabytes the OOM
+# killer would really have let through: what matters is that the complaint does
+# not grow with it.
+PARTIAL_REPORT_BYTES = 100_000
+
+# A tool the OOM killer reached on a big repository, after it had flushed most
+# of a report: a large half-written stdout, a stderr holding nothing but
+# whitespace, and no exit code at all. `fs.writeSync` rather than
+# `process.stdout.write` so the bytes are really in the pipe before the signal
+# lands — a write still queued in the tool would make this case pass for the
+# wrong reason.
+KILLED_MID_REPORT = (
+    'const fs = require("node:fs");\n'
+    f'fs.writeSync(1, "[".padEnd({PARTIAL_REPORT_BYTES}, "x"));\n'
+    'fs.writeSync(2, "  \\n");\n'
+    'process.kill(process.pid, "SIGKILL");\n'
+)
+
+# A run `spawnSync` could not complete: no exit code, an error naming the node
+# it spawned rather than the tool, and whatever the tool got out before it went.
+A_SPAWN_THAT_DIED = {
+    "status": None,
+    "signal": "SIGTERM",
+    "error": {"message": "spawnSync /usr/local/bin/node ENOBUFS"},
+    "stdout": '[{"filePath":"/p/src/a.ts","mess',
+    "stderr": "",
+}
+
+# A spawn that never started at all. `spawnSync` answers with no streams to
+# speak of — absent, not empty — and it is reachable through `run` as E2BIG:
+# the core budgets the *sensor's* argv, and the helper then spawns one process
+# further in with the tool's own script path added
+# (`part_output.py` already concedes the budget can guess wrong). Node 22
+# answers ENOENT the same way.
+A_SPAWN_THAT_NEVER_STARTED = {
+    "status": None,
+    "signal": None,
+    "error": {"message": "spawnSync /usr/local/bin/node E2BIG"},
+    "stdout": None,
+    "stderr": None,
+}
+
+# The same, by a tool that got its own diagnosis out first.
+A_SPAWN_THAT_DIED_AFTER_SPEAKING = {
+    **A_SPAWN_THAT_DIED,
+    "stderr": "Invalid configuration: 'entry' must be an array\n",
+}
+
+
+def _broke_at(tmp_path: Path, tool: str, exit_code: int) -> bool:
+    project = a_project_whose_tool(tmp_path, tool, f"process.exit({exit_code});\n")
+    return ask_the_seam(project, tool)["broke"]
+
+
+def test_a_tool_that_failed_without_a_word_is_named_along_with_its_exit(
+    tmp_path: Path,
+) -> None:
+    project = a_project_whose_tool(tmp_path, "wordless", SAYS_NOTHING)
+
+    answer = ask_the_seam(project, "wordless")
+
+    assert answer["broke"] is True
+    assert answer["complaint"] == "wordless: exited 2 without a word of its own\n"
+
+
+def test_a_tool_killed_mid_report_is_named_along_with_the_signal(
+    tmp_path: Path,
+) -> None:
+    """The complaint stays one sentence, whatever the tool had already printed.
+
+    A killed tool leaves no exit code, so it has to be described by its signal;
+    its whitespace-only stderr is not words; and the report it was halfway
+    through is not a diagnosis. Carrying that report instead would put every
+    flushed byte into a reading agent's context, and it arrives as one line, so
+    nothing downstream can trim it.
+    """
+    project = a_project_whose_tool(tmp_path, "culled", KILLED_MID_REPORT)
+
+    answer = ask_the_seam(project, "culled")
+
+    assert answer["printed"] == PARTIAL_REPORT_BYTES, "the fixture never flushed"
+    assert answer["broke"] is True
+    assert answer["complaint"] == "culled: killed by SIGKILL without a word of its own\n"
+
+
+def test_a_tool_that_diagnosed_itself_is_quoted_in_its_own_words(
+    tmp_path: Path,
+) -> None:
+    project = a_project_whose_tool(tmp_path, "knip", COMPLAINS)
+
+    answer = ask_the_seam(project, "knip")
+
+    assert answer["complaint"] == "knip.json: line 3 is nonsense\n"
+
+
+def test_the_words_a_tool_got_out_outrank_the_spawns_own_error(
+    tmp_path: Path,
+) -> None:
+    """A run can both break and be explained: the tool diagnosed itself before
+    the spawn went down. Its own words win, because `spawnSync`'s name the node
+    that was spawned and leave the reader with nothing to act on."""
+    answer = judge(tmp_path, "knip", A_SPAWN_THAT_DIED_AFTER_SPEAKING)
+
+    assert answer["broke"] is True
+    assert answer["complaint"] == A_SPAWN_THAT_DIED_AFTER_SPEAKING["stderr"]
+
+
+def test_a_spawn_that_died_without_words_names_the_tool_not_the_runtime(
+    tmp_path: Path,
+) -> None:
+    answer = judge(tmp_path, "noisy", A_SPAWN_THAT_DIED)
+
+    assert answer["broke"] is True
+    assert answer["complaint"].startswith("noisy: ")
+    assert "ENOBUFS" in answer["complaint"]
+
+
+def test_a_tool_nobody_installed_is_named_once_in_the_shells_own_phrase(
+    tmp_path: Path,
+) -> None:
+    """The phrase the runner coaches on (``part_output.COMMAND_NOT_FOUND``).
+    The seam already said the tool's name here, so saying it again would leave
+    the one first-contact failure with an obvious fix reading as a stutter."""
+    project = tmp_path / "bare"
+    project.mkdir()
+    (project / "package.json").write_text('{"name": "demo"}', encoding="utf-8")
+
+    answer = ask_the_seam(project, "eslint")
+
+    assert answer["complaint"] == "eslint: command not found\n"
+
+
+def test_a_findings_exit_is_not_breakage(tmp_path: Path) -> None:
+    """Both tools this seam runs exit 1 for "I found something to report" — the
+    commonest successful run there is — so breakage starts above it."""
+    assert _broke_at(tmp_path, "clean", 0) is False
+    assert _broke_at(tmp_path, "reporting", 1) is False
+    assert _broke_at(tmp_path, "broken", 2) is True
+
+
+def test_a_spawn_that_never_started_is_answered_rather_than_read(
+    tmp_path: Path,
+) -> None:
+    """There are no streams here at all, not empty ones — so asking this run
+    what it said has to survive the asking. Reaching for `.trim()` on the
+    absent stderr throws a `TypeError`, which is an unhandled Node traceback in
+    the one place whose whole job is to produce a sentence instead."""
+    answer = judge(tmp_path, "eslint", A_SPAWN_THAT_NEVER_STARTED)
+
+    assert answer["broke"] is True
+    assert answer["complaint"].startswith("eslint: ")
+    assert "E2BIG" in answer["complaint"]

--- a/plugins/typescript/tests/test_a_broken_tool_is_never_silent.py
+++ b/plugins/typescript/tests/test_a_broken_tool_is_never_silent.py
@@ -20,7 +20,9 @@ LINES, which does nothing at all to the single line ``eslint -f json`` emits.
 
 ``project_tool_probe`` is how the seam is asked; what it is asked about is
 here. That its two callers really ask is
-``test_both_node_sensors_refuse_alike.py``.
+``test_both_node_sensors_refuse_alike.py``, and what it makes of a tool cut
+down while reporting — a different fact on each platform — is
+``test_a_tool_killed_mid_report.py``.
 """
 
 from __future__ import annotations
@@ -31,25 +33,6 @@ from project_tool_probe import a_project_whose_tool, ask_the_seam, judge
 
 SAYS_NOTHING = "process.exit(2);\n"
 COMPLAINS = 'process.stderr.write("knip.json: line 3 is nonsense\\n");\nprocess.exit(2);\n'
-
-# Comfortably past a pipe's own 64KB buffer, so the report really is in flight
-# rather than sitting in the tool. Nothing here needs the megabytes the OOM
-# killer would really have let through: what matters is that the complaint does
-# not grow with it.
-PARTIAL_REPORT_BYTES = 100_000
-
-# A tool the OOM killer reached on a big repository, after it had flushed most
-# of a report: a large half-written stdout, a stderr holding nothing but
-# whitespace, and no exit code at all. `fs.writeSync` rather than
-# `process.stdout.write` so the bytes are really in the pipe before the signal
-# lands — a write still queued in the tool would make this case pass for the
-# wrong reason.
-KILLED_MID_REPORT = (
-    'const fs = require("node:fs");\n'
-    f'fs.writeSync(1, "[".padEnd({PARTIAL_REPORT_BYTES}, "x"));\n'
-    'fs.writeSync(2, "  \\n");\n'
-    'process.kill(process.pid, "SIGKILL");\n'
-)
 
 # A run `spawnSync` could not complete: no exit code, an error naming the node
 # it spawned rather than the tool, and whatever the tool got out before it went.
@@ -96,26 +79,6 @@ def test_a_tool_that_failed_without_a_word_is_named_along_with_its_exit(
 
     assert answer["broke"] is True
     assert answer["complaint"] == "wordless: exited 2 without a word of its own\n"
-
-
-def test_a_tool_killed_mid_report_is_named_along_with_the_signal(
-    tmp_path: Path,
-) -> None:
-    """The complaint stays one sentence, whatever the tool had already printed.
-
-    A killed tool leaves no exit code, so it has to be described by its signal;
-    its whitespace-only stderr is not words; and the report it was halfway
-    through is not a diagnosis. Carrying that report instead would put every
-    flushed byte into a reading agent's context, and it arrives as one line, so
-    nothing downstream can trim it.
-    """
-    project = a_project_whose_tool(tmp_path, "culled", KILLED_MID_REPORT)
-
-    answer = ask_the_seam(project, "culled")
-
-    assert answer["printed"] == PARTIAL_REPORT_BYTES, "the fixture never flushed"
-    assert answer["broke"] is True
-    assert answer["complaint"] == "culled: killed by SIGKILL without a word of its own\n"
 
 
 def test_a_tool_that_diagnosed_itself_is_quoted_in_its_own_words(

--- a/plugins/typescript/tests/test_a_file_level_smell_carries_no_line.py
+++ b/plugins/typescript/tests/test_a_file_level_smell_carries_no_line.py
@@ -1,0 +1,91 @@
+"""A smell about the whole file arrives from eslint with no position (#140).
+
+``max-lines`` reports at the first line past the limit, and ``oversized-file``
+is not about that line — the generic ``line-count`` sensor reports the same
+smell about the same file and names no line at all. Carrying eslint's is what
+stopped the two being recognised as one observation, so the reader was coached
+twice about one file.
+
+eslint is stubbed by ``node_tool_stub``, as in
+``test_the_eslint_sensor_shapes_its_findings.py``: the canned report is eslint's
+own JSON shape, so what is under test is the transform and nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from node_tool_stub import install
+
+SENSOR = Path(__file__).parents[1] / "src/habit_hooks_typescript/sensors/eslint.cjs"
+
+ESLINT = "eslint"
+
+
+def _report(rule: str | None, **extra: object) -> str:
+    """One message about ``src/a.ts``, positioned where eslint positions one."""
+    message = {
+        "ruleId": rule,
+        "message": "something to fix",
+        "severity": 2,
+        "line": 201,
+        "column": 1,
+        **extra,
+    }
+    return json.dumps([{"filePath": "/p/src/a.ts", "messages": [message]}])
+
+
+def _details(tmp_path: Path, report: str) -> dict:
+    project = tmp_path / "demo"
+    project.mkdir()
+    (project / "package.json").write_text('{"name": "demo"}', encoding="utf-8")
+    install(project, ESLINT, report)
+    result = subprocess.run(
+        ["node", str(SENSOR), "--", "src/a.ts"],
+        cwd=project,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return json.loads(result.stdout)[0]["issues"][0]["details"]
+
+
+def test_an_oversized_file_names_no_line_and_no_column(tmp_path: Path) -> None:
+    """Line 201 is where eslint's counter tripped, not where the problem is."""
+    details = _details(tmp_path, _report("max-lines"))
+
+    assert details["line"] is None
+    assert details["column"] is None
+
+
+def test_an_oversized_file_still_carries_the_message_eslint_wrote(
+    tmp_path: Path,
+) -> None:
+    """Only the position goes: eslint's own words say how far over the file is,
+    and nothing else reports that."""
+    details = _details(tmp_path, _report("max-lines"))
+
+    assert details["message"] == "something to fix"
+    assert details["source"] == "eslint:max-lines"
+
+
+def test_a_line_level_smell_keeps_the_position_it_was_given(tmp_path: Path) -> None:
+    """Every other smell this sensor emits is about a line, and the line is the
+    only thing telling two of them in one file apart."""
+    details = _details(tmp_path, _report("eqeqeq"))
+
+    assert details["line"] == 201
+    assert details["column"] == 1
+
+
+def test_a_parse_error_keeps_where_parsing_failed(tmp_path: Path) -> None:
+    """``parse-error`` is file-level too — its guide lists files, not lines —
+    but eslint's position on it is where the syntax actually broke, and no other
+    sensor reports it for the same file, so there is nothing to reconcile and
+    real information to lose."""
+    details = _details(tmp_path, _report(None, fatal=True))
+
+    assert details["line"] == 201

--- a/plugins/typescript/tests/test_a_tool_killed_mid_report.py
+++ b/plugins/typescript/tests/test_a_tool_killed_mid_report.py
@@ -1,0 +1,125 @@
+"""What the seam makes of a tool killed while it was still reporting.
+
+The answer is a different fact on each platform, so each half runs where it can
+be told. POSIX ends a process with a signal, and the parent reads
+``status: null, signal: "SIGKILL"`` — a run that plainly never finished. Windows
+has no signals: Node's ``process.kill`` there calls ``TerminateProcess``, and
+the parent reads an ordinary ``status: 1`` with no signal, which is exactly what
+eslint and knip look like when they exit 1 because they found something to
+report.
+
+That asymmetry is the whole reason both halves are written down. On POSIX the
+seam catches it; on Windows nothing at this level can, and what saves the run is
+the sensor one layer out refusing output it cannot read
+(``test_both_node_sensors_refuse_alike.py``). Asserting only the half this
+machine happens to run would leave the other silently unexamined, which is how
+Windows CI came to be the first thing to notice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from platform_probe import A_MACHINE_WITH_SIGNALS, A_MACHINE_WITHOUT_SIGNALS
+from project_tool_probe import a_project_whose_tool, ask_the_seam, run
+
+# Comfortably past a pipe's own 64KB buffer, so the report really is in flight
+# rather than sitting in the tool. Nothing here needs the megabytes the OOM
+# killer would really have let through: what matters is that the complaint does
+# not grow with it.
+PARTIAL_REPORT_BYTES = 100_000
+
+SENSORS = Path(__file__).parents[1] / "src" / "habit_hooks_typescript" / "sensors"
+
+# A tool the OOM killer reached on a big repository, after it had flushed most
+# of a report: a large half-written stdout and a stderr holding nothing but
+# whitespace. One stub, killed the same way on both platforms — what the
+# parent then reads is what differs, and is what each case below states.
+# `fs.writeSync` rather than `process.stdout.write` so the bytes are really in
+# the pipe before the kill lands: a write still queued inside the tool would
+# make either case pass for the wrong reason.
+KILLED_MID_REPORT = (
+    'const fs = require("node:fs");\n'
+    f'fs.writeSync(1, "[".padEnd({PARTIAL_REPORT_BYTES}, "x"));\n'
+    'fs.writeSync(2, "  \\n");\n'
+    'process.kill(process.pid, "SIGKILL");\n'
+)
+
+
+@A_MACHINE_WITH_SIGNALS
+def test_a_tool_killed_mid_report_is_named_along_with_the_signal(
+    tmp_path: Path,
+) -> None:
+    """The complaint stays one sentence, whatever the tool had already printed.
+
+    A killed tool leaves no exit code, so it has to be described by its signal;
+    its whitespace-only stderr is not words; and the report it was halfway
+    through is not a diagnosis. Carrying that report instead would put every
+    flushed byte into a reading agent's context, and it arrives as one line, so
+    nothing downstream can trim it.
+    """
+    project = a_project_whose_tool(tmp_path, "culled", KILLED_MID_REPORT)
+
+    answer = ask_the_seam(project, "culled")
+
+    assert answer["printed"] == PARTIAL_REPORT_BYTES, "the fixture never flushed"
+    assert (answer["status"], answer["signal"]) == (None, "SIGKILL")
+    assert answer["broke"] is True
+    assert answer["complaint"] == "culled: killed by SIGKILL without a word of its own\n"
+
+
+@A_MACHINE_WITH_SIGNALS
+def test_a_sensor_whose_tool_was_killed_says_so_by_its_signal(tmp_path: Path) -> None:
+    """What a reader gets, on the platform where the seam is what caught it."""
+    project = a_project_whose_tool(tmp_path, "knip", KILLED_MID_REPORT)
+
+    result = run(["node", str(SENSORS / "knip.cjs")], project)
+
+    assert result.returncode != 0
+    assert result.stderr == "knip: killed by SIGKILL without a word of its own\n"
+
+
+@A_MACHINE_WITHOUT_SIGNALS
+def test_a_tool_killed_mid_report_looks_exactly_like_a_findings_run(
+    tmp_path: Path,
+) -> None:
+    """The same kill, answered for the platform that has no signals.
+
+    Node's `process.kill` on Windows is `TerminateProcess`, so the parent reads
+    an ordinary exit 1 and no signal — indistinguishable from eslint or knip
+    exiting 1 because they found something to report. This seam does not guess:
+    it reads exit 1 as a findings run, which is the right reading of the only
+    evidence there is.
+
+    What stops the half-written report reaching `JSON.parse` is therefore not
+    here but one layer out, where the sensor refuses output it cannot read
+    (`test_both_node_sensors_refuse_alike.py`). Stated rather than skipped,
+    because a platform gap nothing reports is one nobody closes.
+    """
+    project = a_project_whose_tool(tmp_path, "culled", KILLED_MID_REPORT)
+
+    answer = ask_the_seam(project, "culled")
+
+    assert answer["printed"] == PARTIAL_REPORT_BYTES, "the fixture never flushed"
+    assert (answer["status"], answer["signal"]) == (1, None)
+    assert answer["broke"] is False
+
+
+@A_MACHINE_WITHOUT_SIGNALS
+def test_a_sensor_whose_tool_was_killed_still_refuses_its_half_report(
+    tmp_path: Path,
+) -> None:
+    """The same, on the platform where the seam could not tell.
+
+    Nothing upstream of the parse knows this run died, so this is the assertion
+    that the half-written report never reaches `JSON.parse` — with a real kill
+    rather than the stub that stands in for one everywhere else.
+    """
+    project = a_project_whose_tool(tmp_path, "knip", KILLED_MID_REPORT)
+
+    result = run(["node", str(SENSORS / "knip.cjs")], project)
+
+    assert result.returncode != 0
+    assert result.stderr == (
+        "knip: exited 1, and what it printed is not a report this sensor can read\n"
+    )

--- a/plugins/typescript/tests/test_a_tools_whole_output_reaches_its_sensor.py
+++ b/plugins/typescript/tests/test_a_tools_whole_output_reaches_its_sensor.py
@@ -1,0 +1,114 @@
+"""However much a tool prints, all of it reaches the sensor that ran it.
+
+Node's ``spawnSync`` caps each captured stream at 1 MB unless told otherwise,
+and answers ENOBUFS above it: a truncated stdout, a ``null`` status and an
+``error`` the caller has to notice. A real project crosses that cap easily —
+forty files of ordinary lint findings do — and the sensor is then left with
+nothing it can parse, so a repository full of smells arrives as a broken sensor
+instead of as coaching (#142).
+
+The cap is the seam's question, not either caller's: knip capped its own run
+generously and eslint never capped its own at all, which is the divergence that
+let the bug ship in one of them. So both are asked here, and the answer they
+share comes from ``sensors/project_tool.cjs``. Every other suite in this
+directory drives a report comfortably under the cap, which is the other side of
+that boundary.
+
+eslint is driven for real, because the report that broke #142 was one eslint
+wrote. knip is driven by the recording stub, since what knip would make of a
+huge tree is not the question — how much of what it printed comes back is.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import eslint_project
+from node_tool_stub import install
+
+# What `spawnSync` allows per stream when nobody says otherwise.
+NODE_DEFAULT_MAX_BUFFER = 1024 * 1024
+
+SENSORS = Path(__file__).parents[1] / "src" / "habit_hooks_typescript" / "sensors"
+
+# Each line earns two messages from the shipped config — `no-var` and `eqeqeq` —
+# and eslint reports every one with the file's absolute path, so the fixture is
+# sized to clear the cap by a third rather than to sit on it: where the fixture
+# lives moves the byte count.
+SMELLY_LINES_PER_FILE = 60
+SMELLY_FILES = 40
+
+# Enough unused files for knip's report to cross the cap by the same margin.
+DEAD_FILE_COUNT = 30_000
+DEAD_FILE = "src/generated/never-imported/module-{number:05d}.ts"
+
+
+def _smelly_file() -> str:
+    return "".join(
+        f"var x{n} = 1; if (x{n} == '1') {{}}\n" for n in range(SMELLY_LINES_PER_FILE)
+    )
+
+
+def _a_project_lint_has_a_lot_to_say_about(tmp_path: Path) -> tuple[Path, list[str]]:
+    project = eslint_project.project(tmp_path)
+    source = _smelly_file()
+    files = []
+    for number in range(SMELLY_FILES):
+        name = f"src/smelly{number}.ts"
+        (project / name).write_text(source, encoding="utf-8")
+        files.append(name)
+    return project, files
+
+
+def _messages_in(report: str) -> int:
+    return sum(len(file["messages"]) for file in json.loads(report))
+
+
+def _issues_in(findings: str) -> int:
+    return sum(len(finding["issues"]) for finding in json.loads(findings))
+
+
+def test_the_eslint_sensor_coaches_a_report_over_a_megabyte(tmp_path: Path) -> None:
+    project, files = _a_project_lint_has_a_lot_to_say_about(tmp_path)
+    report = eslint_project.report(project, tuple(files))
+    assert len(report) > NODE_DEFAULT_MAX_BUFFER, "fixture no longer crosses the cap"
+
+    result = eslint_project.sensor_run(project, tuple(files))
+
+    assert result.returncode == 0, result.stderr
+    assert _issues_in(result.stdout) == _messages_in(report)
+
+
+def _a_knip_with_a_lot_to_report(tmp_path: Path) -> tuple[Path, str]:
+    project = tmp_path / "demo"
+    project.mkdir()
+    (project / "package.json").write_text('{"name": "demo"}', encoding="utf-8")
+    report = json.dumps(
+        {
+            "files": [
+                DEAD_FILE.format(number=number) for number in range(DEAD_FILE_COUNT)
+            ],
+            "issues": [],
+        }
+    )
+    install(project, "knip", report)
+    return project, report
+
+
+def test_the_knip_sensor_coaches_a_report_over_a_megabyte(tmp_path: Path) -> None:
+    project, report = _a_knip_with_a_lot_to_report(tmp_path)
+    assert len(report) > NODE_DEFAULT_MAX_BUFFER, "fixture no longer crosses the cap"
+
+    result = subprocess.run(
+        ["node", str(SENSORS / "knip.cjs")],
+        cwd=project,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _issues_in(result.stdout) == DEAD_FILE_COUNT

--- a/plugins/typescript/tests/test_both_node_sensors_refuse_alike.py
+++ b/plugins/typescript/tests/test_both_node_sensors_refuse_alike.py
@@ -1,0 +1,74 @@
+"""Whatever went wrong, both Node sensors say so in the same words.
+
+eslint and knip each wrap a project tool, and each has to turn a run it cannot
+read into a diagnosis. #142 is what happens when they answer that separately:
+knip carried its own failure text and its own output cap, eslint carried
+neither, and the one that carried neither shipped a notice with nothing in it.
+The answer is that both route every unusable run through the one seam
+(``sensors/project_tool.cjs``) — so these cases are deliberately paired, and a
+new one here should be too.
+
+``test_a_broken_tool_is_never_silent.py`` is the other half: what the seam
+answers. This is whether its callers ask.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from project_tool_probe import a_project_whose_tool, run
+
+SENSORS = Path(__file__).parents[1] / "src" / "habit_hooks_typescript" / "sensors"
+
+FAILS_WITHOUT_A_WORD = "process.exit(2);\n"
+
+# A tool that thinks it succeeded and printed nothing at all. Both sensors ask
+# their tool for JSON, and `JSON.parse("")` is a SyntaxError.
+SUCCEEDS_WITHOUT_A_WORD = "process.exit(0);\n"
+
+
+def test_the_eslint_sensor_says_which_tool_failed(tmp_path: Path) -> None:
+    project = a_project_whose_tool(tmp_path, "eslint", FAILS_WITHOUT_A_WORD)
+
+    result = run(["node", str(SENSORS / "eslint.cjs"), "--", "src/a.ts"], project)
+
+    assert result.returncode != 0
+    assert result.stderr == "eslint: exited 2 without a word of its own\n"
+
+
+def test_the_knip_sensor_says_which_tool_failed(tmp_path: Path) -> None:
+    project = a_project_whose_tool(tmp_path, "knip", FAILS_WITHOUT_A_WORD)
+
+    result = run(["node", str(SENSORS / "knip.cjs")], project)
+
+    assert result.returncode != 0
+    assert result.stderr == "knip: exited 2 without a word of its own\n"
+
+
+def test_a_knip_that_reported_nothing_at_all_is_a_diagnosis_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    """A clean exit with an empty stdout leaves nothing to parse, and knip
+    reached `JSON.parse` without asking — so the sensor died with
+    `SyntaxError: Unexpected end of JSON input` and a Node traceback, in the one
+    place that exists to hand the runner a sentence instead. eslint has always
+    asked before parsing; the answer is now the same for both."""
+    project = a_project_whose_tool(tmp_path, "knip", SUCCEEDS_WITHOUT_A_WORD)
+
+    result = run(["node", str(SENSORS / "knip.cjs")], project)
+
+    assert result.returncode != 0
+    assert result.stderr == "knip: exited 0 without a word of its own\n"
+
+
+def test_an_eslint_that_reported_nothing_at_all_is_a_diagnosis_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    """The pair of the case above, kept beside it: this one has always been
+    answered, and it is what knip's answer was matched to."""
+    project = a_project_whose_tool(tmp_path, "eslint", SUCCEEDS_WITHOUT_A_WORD)
+
+    result = run(["node", str(SENSORS / "eslint.cjs"), "--", "src/a.ts"], project)
+
+    assert result.returncode != 0
+    assert result.stderr == "eslint: exited 0 without a word of its own\n"

--- a/plugins/typescript/tests/test_both_node_sensors_refuse_alike.py
+++ b/plugins/typescript/tests/test_both_node_sensors_refuse_alike.py
@@ -22,9 +22,27 @@ SENSORS = Path(__file__).parents[1] / "src" / "habit_hooks_typescript" / "sensor
 
 FAILS_WITHOUT_A_WORD = "process.exit(2);\n"
 
+# The one sentence both sensors owe a run whose output they cannot read.
+UNREADABLE = (
+    "{tool}: exited 1, and what it printed is not a report this sensor can read\n"
+)
+
 # A tool that thinks it succeeded and printed nothing at all. Both sensors ask
 # their tool for JSON, and `JSON.parse("")` is a SyntaxError.
 SUCCEEDS_WITHOUT_A_WORD = "process.exit(0);\n"
+
+# Half an array on stdout and exit 1. This is what a tool killed mid-report
+# looks like to its parent on Windows, where there are no signals and
+# `TerminateProcess` leaves an ordinary exit code — and 1 is the very code
+# eslint and knip use for "I found something to report", so nothing about the
+# run says it died. Written as a stub rather than a real kill so both
+# platforms answer the same case; the kill itself is
+# `test_a_tool_killed_mid_report.py`.
+PRINTS_HALF_A_REPORT = (
+    'const fs = require("node:fs");\n'
+    'fs.writeSync(1, \'[{"filePath":"/p/src/a.ts","messa\');\n'
+    "process.exit(1);\n"
+)
 
 
 def test_the_eslint_sensor_says_which_tool_failed(tmp_path: Path) -> None:
@@ -72,3 +90,28 @@ def test_an_eslint_that_reported_nothing_at_all_is_a_diagnosis_not_a_traceback(
 
     assert result.returncode != 0
     assert result.stderr == "eslint: exited 0 without a word of its own\n"
+
+
+def test_a_knip_whose_report_was_cut_short_is_a_diagnosis_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    """A report that is present and unreadable, which "without a word of its
+    own" would be a lie about — it printed plenty. Left to reach `JSON.parse`
+    it was an unhandled `SyntaxError` and a Node stack trace."""
+    project = a_project_whose_tool(tmp_path, "knip", PRINTS_HALF_A_REPORT)
+
+    result = run(["node", str(SENSORS / "knip.cjs")], project)
+
+    assert result.returncode != 0
+    assert result.stderr == UNREADABLE.format(tool="knip")
+
+
+def test_an_eslint_whose_report_was_cut_short_is_a_diagnosis_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    project = a_project_whose_tool(tmp_path, "eslint", PRINTS_HALF_A_REPORT)
+
+    result = run(["node", str(SENSORS / "eslint.cjs"), "--", "src/a.ts"], project)
+
+    assert result.returncode != 0
+    assert result.stderr == UNREADABLE.format(tool="eslint")

--- a/plugins/typescript/tests/test_knip_speaks_the_smell_vocabulary.py
+++ b/plugins/typescript/tests/test_knip_speaks_the_smell_vocabulary.py
@@ -108,3 +108,34 @@ def test_dropping_an_untranslated_key_leaves_its_neighbours_alone(
 
     assert [f["smell"] for f in findings] == ["unused-file"]
     assert findings[0]["issues"][0]["key"] == "src/orphan.ts"
+
+
+def test_a_column_is_reported_under_the_name_the_contract_gives_it(
+    tmp_path: Path,
+) -> None:
+    """knip spells it `col`; every other sensor and the contract spell it `column`.
+
+    `docs/sensor-interface.spec.md` names `line` / `column` as an issue's
+    location, and forwarding knip's own spelling left that location invisible to
+    everything downstream that asks for it by name — a guide rendering a
+    position, and the mapper deciding whether two issues name one place.
+    Translating the tool's vocabulary is this sensor's job, and a field name is
+    vocabulary like any other.
+    """
+    findings = _findings(
+        tmp_path,
+        {
+            "files": [],
+            "issues": [
+                {
+                    "file": "src/a.ts",
+                    "exports": [{"name": "unused", "line": 3, "col": 14}],
+                }
+            ],
+        },
+    )
+
+    (issue,) = findings[0]["issues"]
+    assert issue["details"]["line"] == 3
+    assert issue["details"]["column"] == 14
+    assert "col" not in issue["details"]

--- a/plugins/typescript/tests/test_the_shipped_knip_config_overlooks_our_own_tools.py
+++ b/plugins/typescript/tests/test_the_shipped_knip_config_overlooks_our_own_tools.py
@@ -1,0 +1,158 @@
+"""habit-hooks does not bill a project for its own footprint.
+
+Setting the typescript plugin up means installing the tools it spawns, jscpd
+for the generic plugin, and the two packages its shipped eslint config resolves
+— the ``--save-dev`` packages the README asks for. The project's own source
+imports none of them, because habit-hooks is what uses them, so knip called
+every one an unused dependency and told the project to delete the tools it had
+just been told to install (#143). The shipped ``knip.json`` overlooks them in
+``ignoreDependencies``. ``knip`` is the exception: it is asked for like the
+rest, and knip leaves itself out of its own answer, so the list does not name
+it.
+
+That list is read out of the config here rather than restated, and whether it
+is the *right* list — complete, and free of anything that is not our footprint
+— is ``tests/test_the_shipped_knip_config_ignores_what_we_asked_for.py``, which
+derives it from every plugin's declarations. This suite asks the next question:
+that knip really honours it, and what must survive it. A dependency the
+*project* stopped using is still its own dead weight, so the fix cannot be a
+blanket "never report an unused dependency". And a project that wrote a knip
+config of its own gets the answer its config gives — ours is the fallback for a
+project that wrote none, never an override (CLAUDE.md, "A wrapped tool's own
+config wins").
+
+The real knip runs here. What the shipped config makes knip do is knip's
+answer, and a stub can only repeat whatever we told it — so the suites that
+stub it ask a different question (which config the sensor named, how a key
+maps), and this one asks the tool.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+PLUGIN = Path(__file__).parents[1]
+PACKAGE = PLUGIN / "src" / "habit_hooks_typescript"
+SENSOR = PACKAGE / "sensors" / "knip.cjs"
+SHIPPED_CONFIG = PACKAGE / "knip.json"
+
+# Read from the config under test, never restated: a second hand-written copy
+# would let the two drift apart, and each would then pass while disagreeing.
+TOOLS_HABIT_HOOKS_REQUIRES = tuple(
+    json.loads(SHIPPED_CONFIG.read_text(encoding="utf-8"))["ignoreDependencies"]
+)
+
+# One the project chose for itself and no longer imports — its own dead weight,
+# and the finding this smell exists for.
+THE_PROJECTS_OWN_DEAD_WEIGHT = "left-pad"
+
+# knip itself, and the compiler it reads .ts with, both of which knip leaves out
+# of its own answer.
+KNIPS_OWN = ("knip", "typescript")
+
+ENTRY = 'import { usedInProduction } from "./helper";\nexport const app = usedInProduction();\n'
+HELPER = (
+    "export function usedInProduction(): number {\n  return 1;\n}\n\n"
+    "export function usedOnlyByTests(): number {\n  return 2;\n}\n"
+)
+TEST = 'import { usedOnlyByTests } from "../src/helper";\n\nusedOnlyByTests();\n'
+
+# A config of the project's own, saying what the shipped one says about the
+# tree and nothing at all about dependencies.
+THEIR_OWN_CONFIG = json.dumps(
+    {"entry": ["src/index.ts!"], "project": ["src/**/*.ts!"]}
+)
+
+
+def _project(tmp_path: Path) -> Path:
+    """A project set up the way the README's step 4 leaves one.
+
+    Its own source imports none of the tools, which is the whole point: they
+    are habit-hooks' dependencies living in the project's manifest.
+    """
+    project = tmp_path / "demo"
+    (project / "src").mkdir(parents=True)
+    (project / "tests").mkdir(parents=True)
+    declared = [*TOOLS_HABIT_HOOKS_REQUIRES, *KNIPS_OWN, THE_PROJECTS_OWN_DEAD_WEIGHT]
+    (project / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "demo",
+                "version": "0.0.0",
+                "devDependencies": {name: "*" for name in sorted(declared)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "src" / "index.ts").write_text(ENTRY, encoding="utf-8")
+    (project / "src" / "helper.ts").write_text(HELPER, encoding="utf-8")
+    (project / "tests" / "helper.test.ts").write_text(TEST, encoding="utf-8")
+    (project / "node_modules").symlink_to(PLUGIN / "node_modules")
+    return project
+
+
+def _findings(project: Path) -> list[dict]:
+    result = subprocess.run(
+        ["node", str(SENSOR)],
+        cwd=project,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _keys_of(findings: list[dict], smell: str) -> set[str]:
+    return {
+        issue["key"]
+        for finding in findings
+        if finding["smell"] == smell
+        for issue in finding["issues"]
+    }
+
+
+def test_the_tools_habit_hooks_asked_for_are_never_the_projects_dead_weight(
+    tmp_path: Path,
+) -> None:
+    reported = _keys_of(_findings(_project(tmp_path)), "unused-dependency")
+
+    assert reported.isdisjoint(TOOLS_HABIT_HOOKS_REQUIRES), reported
+
+
+def test_a_dependency_the_project_itself_stopped_using_is_still_reported(
+    tmp_path: Path,
+) -> None:
+    """Overlooking our own footprint must not become overlooking theirs."""
+    reported = _keys_of(_findings(_project(tmp_path)), "unused-dependency")
+
+    assert reported == {THE_PROJECTS_OWN_DEAD_WEIGHT}
+
+
+def test_a_project_that_wrote_its_own_config_gets_its_own_answer(
+    tmp_path: Path,
+) -> None:
+    """Their config decides, ours is not in force, and what it overlooks is not
+    overlooked for them. Reporting our tools here is the correct answer to the
+    config they wrote — the fix is a fallback config, never a filter over knip's
+    findings, which would speak over every project's config alike."""
+    project = _project(tmp_path)
+    (project / "knip.json").write_text(THEIR_OWN_CONFIG, encoding="utf-8")
+
+    reported = _keys_of(_findings(project), "unused-dependency")
+
+    assert reported.issuperset(TOOLS_HABIT_HOOKS_REQUIRES), reported
+
+
+def test_the_gated_production_pass_still_runs_under_the_shipped_config(
+    tmp_path: Path,
+) -> None:
+    """`--production` is gated on a trailing `!` marking both `entry` and
+    `project`, read straight out of the config in force. A new key alongside
+    them must leave that reading alone, or the second pass silently stops."""
+    findings = _findings(_project(tmp_path))
+
+    assert _keys_of(findings, "test-only-dead-code") == {"usedOnlyByTests"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "habit-hooks"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 description = "Turn best-practice coding advice into AI habits — structural code-smell coaching for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/habit_hooks/git_command.py
+++ b/src/habit_hooks/git_command.py
@@ -1,0 +1,61 @@
+"""Ask one git question inside a project, and hand back what git said.
+
+This is the spawning policy every question in ``git_history`` shares — the
+project as the working directory, output captured and decoded as UTF-8, an empty
+stdin — held apart from the questions themselves. How a thing is asked is a
+smaller and stabler concern than what is asked and what its answer means, and
+this is the half with one reason to change; it is the same line, in the same
+direction, as ``part_output`` → ``diagnosis`` and ``mapper`` → ``rendering``.
+The dependency runs one way: ``git_history`` imports from here, never back.
+
+All three answers degrade rather than raise. There is nothing a message could
+usefully say about a machine with no git on it, so ``git`` answers ``None`` when
+the program could not be run at all, ``git_output`` answers empty text on any
+failure whatever, and ``git_succeeded`` answers ``False``. What to make of any
+of those silences is the asking module's decision, not this one's — an empty
+answer is never allowed to quietly mean "nothing there".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git(project_dir: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+    """``git <args>`` in the project, or ``None`` when git could not be run at all.
+
+    Every call is handed an empty stdin: ``hash-object --stdin`` needs one, and
+    no other question asked here reads input, so none of them can sit waiting for
+    one that never comes.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=project_dir,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",  # sensors.spawn's policy
+            input="",
+        )
+    except OSError:
+        return None
+
+
+def git_output(project_dir: Path, *args: str) -> str:
+    """``git <args>`` output, or empty on any failure — the safe degrade."""
+    result = git(project_dir, *args)
+    if result is None or result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def git_succeeded(project_dir: Path, *args: str) -> bool:
+    """Whether ``git <args>`` answered yes, for the questions git answers by exit
+    code alone (``--is-inside-work-tree``, ``check-ignore --quiet``).
+
+    A git that could not be run and a git that said no are one answer here: both
+    are the absence of a yes, and neither is a mistake the caller can report.
+    """
+    result = git(project_dir, *args)
+    return result is not None and result.returncode == 0

--- a/src/habit_hooks/git_history.py
+++ b/src/habit_hooks/git_history.py
@@ -1,5 +1,5 @@
-"""Ask git where a branch left its base ref, which paths differ since, and which
-files the project keeps at all.
+"""Ask git what it remembers: where a branch left its base ref, and which paths
+differ since.
 
 Two callers put the same question in the same words — a scoped run
 (``scope.py``) and a lapsing snooze (``changed_files.py``) — and they differ only
@@ -8,15 +8,21 @@ in what they make of silence. The facts live here so there is one answer:
 snooze, and a flag this module gets right cannot be missing from the other
 caller. Each caller keeps its own policy for the two silences: a directory git
 cannot place, and a ref a real repository does not have.
+
+What git says about the working tree *as it stands* — which files the project
+holds, which of them it ignores — is ``git_listing``, asked from here only to
+widen a diff with the untracked work it cannot name. How any of it is spawned is
+``git_command``'s, one module further down.
 """
 
 from __future__ import annotations
 
-import subprocess
 from collections.abc import Collection
 from pathlib import Path
 
 from .argv_budget import within_argument_limits
+from .git_command import git, git_output, git_succeeded
+from .git_listing import untracked_paths
 
 
 def places_directory(project_dir: Path) -> bool:
@@ -26,8 +32,7 @@ def places_directory(project_dir: Path) -> bool:
     to ask. Neither is a mistake a message could help with, so each caller
     degrades rather than failing on it.
     """
-    placed = _run(project_dir, "rev-parse", "--is-inside-work-tree")
-    return placed is not None and placed.returncode == 0
+    return git_succeeded(project_dir, "rev-parse", "--is-inside-work-tree")
 
 
 def resolves(project_dir: Path, ref: str) -> str | None:
@@ -37,7 +42,7 @@ def resolves(project_dir: Path, ref: str) -> str | None:
     branch changed nothing" — a clean run over an unscanned tree.
     ``--verify --quiet`` is what tells the two apart.
     """
-    verified = _run(project_dir, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+    verified = git(project_dir, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
     if verified is None or verified.returncode != 0:
         return None
     return verified.stdout.strip()
@@ -53,12 +58,12 @@ def forked_at(project_dir: Path, ref: str, tip: str) -> str:
     name, and the ref's own tip is then the only comparison there is; comparing
     against nothing would scope a run to nothing.
     """
-    return _stdout(project_dir, "merge-base", ref, "HEAD") or tip
+    return git_output(project_dir, "merge-base", ref, "HEAD") or tip
 
 
 def head_branch(project_dir: Path) -> str:
     """The branch ``HEAD`` is on, or empty when it is not on one."""
-    return _stdout(project_dir, "rev-parse", "--abbrev-ref", "HEAD")
+    return git_output(project_dir, "rev-parse", "--abbrev-ref", "HEAD")
 
 
 def empty_tree(project_dir: Path) -> str:
@@ -68,7 +73,7 @@ def empty_tree(project_dir: Path) -> str:
     spelling, and a SHA-256 repository has its own. Diffing against it is how a
     history shorter than the question gets answered with all of itself.
     """
-    return _stdout(project_dir, "hash-object", "-t", "tree", "--stdin")
+    return git_output(project_dir, "hash-object", "-t", "tree", "--stdin")
 
 
 def changed_paths(
@@ -98,49 +103,6 @@ def changed_paths(
     ]
 
 
-def untracked_paths(project_dir: Path) -> list[str]:
-    """New files git is not tracking and not ignoring, in the project's own terms.
-
-    ``git diff`` never names an untracked path, so the file just written — the one
-    most likely to carry a smell — is the file a diff-built scope cannot see.
-    """
-    return _listed_files(project_dir, "--others")
-
-
-def project_files(project_dir: Path) -> list[str]:
-    """Every file this project keeps: what git tracks, plus what it has just
-    written and does not ignore.
-
-    What a project ignores is not its own, and nothing else knows that as
-    cheaply: a ``node_modules`` full of ``.d.ts`` would otherwise answer for what
-    language a project is written in. Outside a repository — and where there is
-    no git to ask — the answer is empty, the silence every question here
-    degrades to.
-    """
-    return _listed_files(project_dir, "--cached", "--others")
-
-
-def _listed_files(project_dir: Path, *selectors: str) -> list[str]:
-    """What ``git ls-files`` names under ``selectors``, in the project's own terms.
-
-    ``--exclude-standard`` keeps ignored files out: a build artifact is neither
-    work in progress nor source. ``-z`` stops a non-ASCII name being quoted (and
-    then matching nothing), and ``--literal-pathspecs`` keeps a path a plain path
-    — the same guards the batched diff needs. Run inside ``project_dir``,
-    ``ls-files`` names paths relative to it, matching ``--relative`` on the diffs
-    they unite with.
-    """
-    named = _stdout(
-        project_dir,
-        "--literal-pathspecs",
-        "ls-files",
-        *selectors,
-        "--exclude-standard",
-        "-z",
-    )
-    return [path for path in named.split("\0") if path]
-
-
 def uncommitted_changes(project_dir: Path) -> list[str]:
     """The work in progress a commit-to-commit diff misses: staged and unstaged
     edits to tracked files, and brand-new untracked files.
@@ -159,7 +121,7 @@ def uncommitted_changes(project_dir: Path) -> list[str]:
 def _diff_names(
     project_dir: Path, revisions: Collection[str], pathspecs: Collection[str]
 ) -> list[str]:
-    named = _stdout(
+    named = git_output(
         project_dir,
         "--literal-pathspecs",
         "diff",
@@ -171,30 +133,3 @@ def _diff_names(
         *pathspecs,
     )
     return [path for path in named.split("\0") if path]
-
-
-def _run(project_dir: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
-    """``git <args>`` in the project, or ``None`` when git could not be run at all.
-
-    Every call is handed an empty stdin: ``hash-object --stdin`` needs one, and
-    no other question here reads input, so none of them can sit waiting for it.
-    """
-    try:
-        return subprocess.run(
-            ["git", *args],
-            cwd=project_dir,
-            capture_output=True,
-            encoding="utf-8",
-            errors="replace",  # sensors.spawn's policy
-            input="",
-        )
-    except OSError:
-        return None
-
-
-def _stdout(project_dir: Path, *args: str) -> str:
-    """``git <args>`` output, or empty on any failure — the safe degrade."""
-    result = _run(project_dir, *args)
-    if result is None or result.returncode != 0:
-        return ""
-    return result.stdout.strip()

--- a/src/habit_hooks/git_listing.py
+++ b/src/habit_hooks/git_listing.py
@@ -1,0 +1,148 @@
+"""What git says about the working tree as it stands: which files this project
+holds, and which of them it was told to forget.
+
+The counterpart to ``git_history``, which asks what git *remembers* — refs,
+merge bases, the diff between two revisions. Both spawn through ``git_command``
+and neither is the other's caller's business: a scope built from history asks
+here only to widen itself with untracked work, and a whole-project scan asks
+here alone. Splitting them is what keeps each under the repo's own 200-line
+``oversized-file`` gate, and it is the same line, in the same direction, as
+``config`` → ``config_schema`` and ``part_output`` → ``diagnosis``.
+
+Every answer degrades to empty or ``False``, never to an exception: outside a
+repository and on a machine with no git, nothing here is a mistake a message
+could help with. What to make of that silence is the caller's decision — and no
+caller is allowed to read it as "nothing there".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .git_command import git_output, git_succeeded
+
+# What git stores a submodule mount point as. A tracked symlink is 120000 and an
+# ordinary file 100644, so this one value separates a gitlink from everything.
+_GITLINK_MODE = "160000 "
+
+
+def ignores_directory(project_dir: Path) -> bool:
+    """Whether the repository around this directory ignores the directory itself.
+
+    A project can sit inside somebody else's ignored tree — this repository runs
+    its own spec cases under a ``.spec-runs/`` its ``.gitignore`` covers, and
+    each case is a real project. Every file in such a project is ignored, by a
+    rule that was never about that project, so what git keeps there is nothing
+    at all. A caller filtering by that answer would scope the run to zero files
+    and report the lot clean, which is why it asks this first and stands down.
+
+    ``--no-index`` is what makes this a question about the ignore rules rather
+    than about the index, and it is the whole reason the guard is worth having.
+    An empty answer a caller can already spot for itself; by default
+    ``check-ignore`` calls a directory holding anything the outer repository
+    tracks — a file force-added under an ignored path — "not ignored", so the
+    guard would stand down for exactly the project whose file list comes back
+    **partial**. Partial is the dangerous shape: it looks like a real answer, so
+    the run scans the one force-added file and pronounces every other file clean
+    without reading it.
+
+    **A repository never ignores its own root**, and asking about it anyway is
+    how the guard used to misfire. The question was ``check-ignore .``, whose
+    answer for the root of a repository is whatever its own ``.gitignore`` says
+    about the name ``.`` — so a file opening ``*`` and listing exceptions after
+    it, the ordinary allow-list shape, reported its own project ignored and
+    threw away a perfectly good file list. The root is therefore settled first,
+    against ``rev-parse --show-toplevel``, and only a project *below* a
+    repository root is asked about at all.
+
+    The path is then spelled out in full rather than as ``.``: a nested project
+    with an allow-list ``.gitignore`` of its own has the same ``*`` matched
+    against the same ``.`` otherwise, and answers "ignored" about a directory
+    the repository above it is perfectly happy with.
+
+    False where there is no repository, and where there is no git to ask:
+    nothing ignores anything then either.
+    """
+    if _is_a_repository_root(project_dir):
+        return False
+    return git_succeeded(
+        project_dir, "check-ignore", "--no-index", "--quiet", "--", str(project_dir)
+    )
+
+
+def _is_a_repository_root(project_dir: Path) -> bool:
+    """Whether this directory is the top of the repository that answers for it.
+
+    Asked of git rather than by looking for a ``.git`` entry, so a linked
+    worktree (whose ``.git`` is a file) and a ``GIT_DIR`` pointed elsewhere are
+    both answered correctly. Resolved on both sides before comparing: git always
+    reports a real path, and on macOS a ``/var/...`` project is ``/private/var``
+    to git.
+    """
+    top = git_output(project_dir, "rev-parse", "--show-toplevel")
+    return bool(top) and Path(top).resolve() == project_dir.resolve()
+
+
+def project_files(project_dir: Path) -> list[str]:
+    """Every file this project keeps: what git tracks, plus what it has just
+    written and does not ignore.
+
+    What a project ignores is not its own, and nothing else knows that as
+    cheaply: a ``node_modules`` full of ``.d.ts`` would otherwise answer for what
+    language a project is written in. Outside a repository — and where there is
+    no git to ask — the answer is empty, the silence every question here
+    degrades to.
+    """
+    return _listed_files(project_dir, "--cached", "--others")
+
+
+def untracked_paths(project_dir: Path) -> list[str]:
+    """New files git is not tracking and not ignoring, in the project's own terms.
+
+    ``git diff`` never names an untracked path, so the file just written — the one
+    most likely to carry a smell — is the file a diff-built scope cannot see.
+    """
+    return _listed_files(project_dir, "--others")
+
+
+def submodule_paths(project_dir: Path) -> list[str]:
+    """Where this project mounts other repositories, as git recorded them.
+
+    Asked of the index, never of the filesystem. A submodule is a **gitlink**,
+    which git stores with mode ``160000`` and nothing else has — so the question
+    has an exact answer and needs no ``.gitmodules`` to parse.
+
+    ``Path.is_dir()`` cannot answer it: it follows symlinks, so a *tracked
+    symlink to a directory* (mode ``120000``) looks identical to a gitlink. That
+    is not a corner case — a symlinked ``node_modules`` is pnpm's ordinary
+    layout, so the filesystem question calls an everyday JavaScript project's
+    dependency tree a submodule.
+
+    ``ls-files --stage`` prints ``<mode> <object> <stage>\\t<path>``; ``-z``
+    keeps a non-ASCII path unquoted, as everywhere else here.
+    """
+    listed = git_output(project_dir, "ls-files", "--stage", "-z")
+    return [
+        entry.split("\t", 1)[1]
+        for entry in listed.split("\0")
+        if entry.startswith(_GITLINK_MODE) and "\t" in entry
+    ]
+
+
+def _listed_files(project_dir: Path, *selectors: str) -> list[str]:
+    """What ``git ls-files`` names under ``selectors``, in the project's own terms.
+
+    ``--exclude-standard`` keeps ignored files out: a build artifact is neither
+    work in progress nor source. ``-z`` stops git quoting a non-ASCII name as
+    ``"caf\\303\\251.py"``, which then names nothing on disk and is silently
+    dropped from the answer. Run inside ``project_dir``, ``ls-files`` names paths
+    relative to it, matching the ``--relative`` on the diffs they unite with.
+
+    No ``--literal-pathspecs`` here, unlike the batched diff: that flag governs
+    how a *pathspec argument* is read, and every question asked here passes only
+    selectors. Adding one means adding the flag with it.
+    """
+    named = git_output(
+        project_dir, "ls-files", *selectors, "--exclude-standard", "-z"
+    )
+    return [path for path in named.split("\0") if path]

--- a/src/habit_hooks/initialise.py
+++ b/src/habit_hooks/initialise.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from attrs import frozen
 
-from . import git_history
+from . import git_listing
 from .config import declared_detectors, load_config, project_config_path
 from .config_schema import Config
 from .detectors import Detector
@@ -95,7 +95,7 @@ class Plan:
 
 def plan(project_dir: Path) -> Plan:
     """Everything setting this project up needs decided, and nothing acted on."""
-    files = git_history.project_files(project_dir)
+    files = git_listing.project_files(project_dir)
     languages = tuple(used_languages(project_dir, files))
     config = _project_config(project_dir)
     plugins = _plugins(languages, config)

--- a/src/habit_hooks/mapper.py
+++ b/src/habit_hooks/mapper.py
@@ -14,8 +14,16 @@ from pathlib import Path
 
 from .catalogue import incomplete_run_finding
 from .cli import EXIT_TOOL_ERROR, add_version_flag, run_console
-from .config import load_config
-from .rendering import Rendered, block, is_disabled, render_clean, render_finding
+from .config import Config, load_config
+from .merged_findings import merged
+from .rendering import (
+    Rendered,
+    block,
+    is_disabled,
+    render_clean,
+    render_finding,
+    resolve_guide,
+)
 from .resolve import Resolver
 
 EMPTY_STDIN_NOTICE = (
@@ -30,12 +38,23 @@ def write_stderr(rendered: list[Rendered]) -> None:
             sys.stderr.write(r.stderr)
 
 
+def coachable(findings: list[dict], config: Config, resolver: Resolver) -> list[dict]:
+    """The findings this run prints: what the project coaches, one per guide.
+
+    Two sensors seeing one smell are one finding by the time anything renders
+    (:mod:`habit_hooks.merged_findings`), and which guide each would render is
+    what decides who merges with whom.
+    """
+    coached = [f for f in findings if not is_disabled(f["smell"], config)]
+    return merged(coached, lambda f: resolve_guide(f, config, resolver))
+
+
 def run(
     findings: list[dict], project_dir: Path, config_path: Path | None = None
 ) -> int:
     config = load_config(project_dir, config_path)
     resolver = Resolver.discover(project_dir)
-    findings = [f for f in findings if not is_disabled(f["smell"], config)]
+    findings = coachable(findings, config, resolver)
     if not findings:
         clean = render_clean(config, resolver)
         sys.stdout.write(clean.text)

--- a/src/habit_hooks/merged_findings.py
+++ b/src/habit_hooks/merged_findings.py
@@ -1,0 +1,134 @@
+"""Findings that would print the same guide are one finding.
+
+Two sensors can see one smell — eslint's ``max-lines`` and the generic
+``line-count`` sensor both report ``oversized-file`` — and one sensor can report
+a smell many times over, as jscpd does, a finding per clone. The mapper prints
+one block per finding, so left alone each of those became another copy of the
+same ~200-word guide (#140).
+
+**The guide is the thing merged on, not the smell.** One guide printed twice is
+the whole waste being removed, so merging exactly what renders alike is correct
+by construction — and merging by smell alone is not: `high-complexity` from the
+python plugin and from the typescript plugin route to *different* guides
+(``rendering.resolve_guide``, off the finding's ``language``), and folding them
+together coaches a ``.ts`` file in Python. Keying on ``language`` instead is no
+fix either, since ``generic`` declares none and would stop #140 being fixed at
+all.
+
+Merging is the mapper's, not the sensors stage's: what a sensor emitted is the
+run's own record, read by ``habit-snooze``, so a snooze key must not depend on
+who else saw the same file. It happens before anything is rendered, so
+:mod:`habit_hooks.rendering` still renders exactly one finding and knows nothing
+about this — the guide arrives as a callable the mapper supplies.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Hashable
+
+# The keys the merge settles itself, so the loop over the rest must skip them.
+SETTLED_BY_THE_MERGE = ("smell", "details", "issues")
+
+# Where an issue's details say the observation is. ``file`` and ``line``/
+# ``column`` are the finding contract's own location fields
+# (docs/sensor-interface.spec.md); a smell may spell the place its own way, and
+# ``duplicated-code`` does — a jscpd occurrence names a RANGE and no line, so
+# leaving its bounds out would read two clones of one file as one duplication.
+PLACE_FIELDS = ("file", "line", "column", "startLine", "endLine")
+
+
+def merged(
+    findings: list[dict], guide_of: Callable[[dict], Hashable]
+) -> list[dict]:
+    """One finding per smell and guide, in the order the first of each arrived.
+
+    ``guide_of`` answers which guide a finding would render — the mapper's own
+    resolution, passed in so this module never learns about ``Config`` or
+    ``Resolver``. The smell is in the key too: a ``[smells.<name>] guide``
+    override can point two smells at one file, and their banners still name
+    them separately.
+    """
+    groups: dict[tuple, list[dict]] = {}
+    for finding in findings:
+        groups.setdefault((finding["smell"], guide_of(finding)), []).append(finding)
+    return [_one_finding(group) for group in groups.values()]
+
+
+def _one_finding(group: list[dict]) -> dict:
+    """The findings of one group as the single finding that renders for them.
+
+    A top-level key other than the three below is **first non-null**: the
+    runner stamps ``language`` from the producing plugin and ``generic``
+    declares none, so a null must not out-rank a real answer. It cannot pick a
+    language from outside the group — every member resolves to the group's one
+    guide, so re-resolving with any of theirs lands there too.
+
+    Built rather than edited: ``merged`` answers a question about the findings
+    it is handed and does not rewrite them.
+    """
+    finding = dict(group[0])
+    for later in group[1:]:
+        for name, value in later.items():
+            if name not in SETTLED_BY_THE_MERGE and finding.get(name) is None:
+                finding[name] = value
+    finding["details"] = _agreed_facts(group)
+    finding["issues"] = _issues_across(group)
+    return finding
+
+
+def _agreed_facts(group: list[dict]) -> dict:
+    """The smell-level ``details`` the group does not contradict itself about.
+
+    Not first-come: a fact only one finding states is kept — ``line-count``
+    names the threshold it enforced and eslint does not — but a fact two of
+    them state *differently* is **dropped**: jscpd's ``lines``/``tokens``
+    describe one clone pair, and three pairs merged would otherwise publish the
+    first pair's numbers as the whole finding's. A guide reading a missing key
+    renders nothing; one reading a wrong number teaches the reader something
+    untrue. A key stays dropped once contradicted, however many later findings
+    happen to restate the first value.
+    """
+    agreed: dict = {}
+    contradicted: set = set()
+    for finding in group:
+        for name, fact in (finding.get("details") or {}).items():
+            if name in contradicted:
+                continue
+            if name not in agreed:
+                agreed[name] = fact
+            elif agreed[name] != fact:
+                del agreed[name]
+                contradicted.add(name)
+    return agreed
+
+
+def _issues_across(group: list[dict]) -> list[dict]:
+    """Every issue of the first finding, then whatever the later ones add.
+
+    Deduplication is **across** findings only. A sensor's own issue list is
+    authoritative — it meant the seven long functions it reported, and the two
+    comments it found on one line — and three shipped sensors (``pmd``,
+    ``phpmd``, ``comment``) key by file and give no column, so two of their
+    issues on one line are one observation by any identity this can build.
+    Second-guessing that is not the merge's job; #140 is about two *sensors*
+    reporting one thing.
+    """
+    issues = list(group[0].get("issues") or [])
+    seen = {_observation(issue) for issue in issues}
+    for later in group[1:]:
+        own = later.get("issues") or []
+        issues.extend(issue for issue in own if _observation(issue) not in seen)
+        seen.update(_observation(issue) for issue in own)
+    return issues
+
+
+def _observation(issue: dict) -> tuple:
+    """What an issue is *about*: its snooze key, and the place it names.
+
+    Nothing either tool said in its own voice counts — two sensors seeing one
+    thing disagree on ``source`` and ``message`` precisely because they are two
+    tools. A field neither stated and a field stated as ``null`` both come back
+    ``None``, which is the same absence and has to compare as one.
+    """
+    details = issue.get("details") or {}
+    return (issue.get("key"), *(details.get(field) for field in PLACE_FIELDS))

--- a/src/habit_hooks/path_globs.py
+++ b/src/habit_hooks/path_globs.py
@@ -1,0 +1,25 @@
+"""Keep the paths a list of globs matches, gitignore-style.
+
+One filter, asked by everything that narrows a path list: the run's ``[files]``
+(``scope``), a single sensor's own ``files`` (``sensors/execution``), and the
+question of whether a submodule held anything this run wanted (``scope_notices``).
+
+It lives on its own so those three cannot come to disagree, and so the two that
+are not ``scope`` need not import it — ``scope_notices`` is ``scope``'s own
+dependency, and importing back would be a cycle.
+"""
+
+from __future__ import annotations
+
+import pathspec
+
+
+def matching(paths: list[str], globs: list[str]) -> list[str]:
+    """The ``paths`` kept by pathspec (gitignore) ``globs``, order preserved.
+
+    Gitignore semantics, so a later negation overrides an earlier match and
+    there is no brace expansion. An empty ``globs`` keeps nothing, which is what
+    makes discovery opt-in (#97) rather than accidentally universal.
+    """
+    spec = pathspec.PathSpec.from_lines("gitignore", globs)
+    return [path for path in paths if spec.match_file(path)]

--- a/src/habit_hooks/project_scan.py
+++ b/src/habit_hooks/project_scan.py
@@ -1,0 +1,82 @@
+"""Every file a project has: what git says it keeps, or what is on disk when git
+is not the thing to ask.
+
+A whole-project run used to walk the directory tree and measure whatever it
+found, while every git-derived mode asked git and so had never seen a build
+artifact in its life. One project, two universes (#142): a real pnpm monorepo
+held 321 tracked ``.ts``/``.tsx`` files and 843 on disk — 181 in ``dist/``, 326
+in a tool cache, 14 in ``.next/`` — and its owner had to hand-write
+``!**/dist/**`` into ``[files]`` before a run was usable. A default somebody has
+to patch is the wrong default, so the walk is now the fallback and git's list is
+the answer.
+
+What a run then makes of that list — the ``[files]`` narrowing, dropping paths
+the work tree no longer has, the opt-in that stops any of it happening at all —
+is ``scope.py``, which is this module's only caller. The dependency runs one
+way, and on through ``git_listing`` to ``git_command``: what a project holds is
+a smaller question than what a run measures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import git_listing
+
+
+def files_in(project_dir: Path) -> list[str]:
+    """The project's own files, sorted — git's account of them where there is one.
+
+    Git saying nothing is never read as "nothing to scan". Outside a repository,
+    on a machine with no git, and on any failure at all, git's answer is empty
+    and the disk answers instead: a run that over-scans is a nuisance, where one
+    that silently scans nothing reports a whole tree clean without reading it.
+    """
+    return sorted(_files_git_keeps(project_dir) or _files_on_disk(project_dir))
+
+
+def _files_git_keeps(project_dir: Path) -> list[str]:
+    """What git tracks here, plus what was just written and is not ignored — or
+    nothing, when this project is the wrong thing to ask git about.
+
+    Untracked-but-not-ignored has to be in it: the file just written is the one
+    most likely to carry a fresh smell, and narrowing to the index alone would
+    be a worse bug than the one this fixes.
+
+    A project that is *itself* ignored by the repository around it has every file
+    in it ignored, by a rule that was never about this project — a checkout
+    vendored into somebody's ``vendor/``, or one of this repository's own spec
+    cases under the ``.spec-runs/`` its ``.gitignore`` covers. Trusting git there
+    would scope the run to nothing and call the lot clean, so the directory is
+    asked about first and the list given up rather than believed.
+
+    A submodule comes back as its own directory and never the files inside it,
+    so a submodule's source leaves the scope. That is what every git-derived mode
+    already does with it — ``git diff`` does not descend into a submodule either
+    — and it is another repository, which gates itself.
+    """
+    if git_listing.ignores_directory(project_dir):
+        return []
+    return git_listing.project_files(project_dir)
+
+
+def _files_on_disk(project_dir: Path) -> list[str]:
+    """Every file under the project, whatever any repository makes of it.
+
+    ``as_posix`` rather than ``str``: git names a nested file ``src/a.py`` on
+    every platform, and this branch builds its own strings out of ``os.sep`` —
+    a backslash on Windows.
+
+    The payoff is the **sort** in :func:`files_in`, which orders whatever these
+    two branches produce. ``\\`` and ``/`` sort differently, so on Windows the
+    same project would come back in one order from git and another from the
+    walk. No caller ever sees the backslash itself — ``scope._placed`` puts
+    every path through ``project_paths.project_relative``, which normalises
+    again — so this is about the two branches being interchangeable, not about
+    a spelling escaping into a finding.
+    """
+    return [
+        path.relative_to(project_dir).as_posix()
+        for path in project_dir.rglob("*")
+        if path.is_file()
+    ]

--- a/src/habit_hooks/rendering.py
+++ b/src/habit_hooks/rendering.py
@@ -144,7 +144,13 @@ def _refuse_unconfigured_runner(smell: str, guide: Path, extension: str) -> NoRe
     )
 
 
-def _resolve_guide(finding: dict, config: Config, resolver: Resolver) -> Path:
+def resolve_guide(finding: dict, config: Config, resolver: Resolver) -> Path:
+    """The guide a finding renders, off its smell and its language.
+
+    Public because the mapper asks it *before* rendering: findings that would
+    print the same guide are merged into one (:mod:`habit_hooks.merged_findings`),
+    and only this answers which those are.
+    """
     plugins = plugins_for_language(finding.get("language"), config)
     guide = resolver.first(plugins, guide_names(finding["smell"], config))
     if guide is None:
@@ -164,7 +170,7 @@ def _runner_for(config: Config, guide: Path, smell: str) -> str:
 def render_finding(finding: dict, config: Config, resolver: Resolver) -> Rendered:
     smell = finding["smell"]
     enforced = severity_of(smell, config) == ENFORCED
-    guide = _resolve_guide(finding, config, resolver)
+    guide = resolve_guide(finding, config, resolver)
     if guide.suffix == ".md":
         environment = include_environment(config.plugins, resolver)
         rendered = render_markdown(guide, finding, environment)

--- a/src/habit_hooks/rendering.py
+++ b/src/habit_hooks/rendering.py
@@ -109,13 +109,26 @@ def render_markdown(guide: Path, finding: dict, environment: Environment) -> Ren
 
 
 def render_runner(guide: Path, runner: str, finding: dict) -> Rendered:
-    result = subprocess.run(
-        [runner, str(guide)],
-        input=json.dumps(finding),
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",  # sensors.spawn's policy
-    )
+    # A runner nobody installed is the same first-contact mistake as a sensor's
+    # missing tool, and #114's sweep reached the sensors stage but not here — so
+    # a typo in [runners] answered with a FileNotFoundError traceback, which
+    # `cli.run_console` does not catch. The guide is named beside the command
+    # because a project routes a smell to a runner by the guide's *extension*,
+    # so which file asked for this is the reader's next question.
+    try:
+        result = subprocess.run(
+            [runner, str(guide)],
+            input=json.dumps(finding),
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",  # sensors.spawn's policy
+        )
+    except OSError as refusal:
+        raise ToolError(
+            f"habit-mapper: guide {guide.name!r} runs through {runner!r}, which "
+            f"would not start ({refusal.strerror}) — install it, fix the "
+            f"[runners] entry, or route the smell to a .md guide"
+        ) from None
     return Rendered(
         text=result.stdout,
         blocks=result.returncode != 0,

--- a/src/habit_hooks/scope.py
+++ b/src/habit_hooks/scope.py
@@ -4,8 +4,10 @@ The scope flags are mutually exclusive; with none, the scope is derived from the
 ``[scope]`` config. Git-backed modes measure a branch from the same merge base a
 lapsing snooze asks ``git_history`` for, then widen the answer to the uncommitted
 work in progress — the staged and untracked files a diff alone would miss (#92).
-The picked paths are then narrowed to the files the work tree still has and
-``[files]`` calls source (pathspec/gitignore globbing, no brace expansion).
+Whole-project modes ask ``project_scan`` for the files the project keeps, which
+is git's answer too, so no mode measures a universe another one cannot see
+(#142). The picked paths are then narrowed to the files the work tree still has
+and ``[files]`` calls source (pathspec/gitignore globbing, no brace expansion).
 """
 
 from __future__ import annotations
@@ -14,13 +16,12 @@ import argparse
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import pathspec
-
-from . import git_history
+from . import git_history, project_scan
+from .path_globs import matching
 from .cli import ToolError
 from .config import Config
 from .project_paths import project_relative
-from .scope_notices import empty_scope_notices
+from .scope_notices import empty_scope_notices, submodule_notices
 
 # What to tell someone whose base ref is not in their checkout, named after
 # whatever chose the ref — the setting they can act on differs per mode.
@@ -32,8 +33,10 @@ _SINCE_FLAG = "pass --since a ref it has"
 @dataclass
 class Scope:
     files: list[str]
-    # Why a run scanned nothing, when that is worth saying out loud. Non-fatal:
-    # a `--file` hook fires on every edit, including files a project won't scan.
+    # What the reader must know about this scope that its files do not show: why
+    # it came out empty, and any submodule it left out. Non-fatal, and written to
+    # stderr — a `--file` hook fires on every edit, including files a project
+    # won't scan, and a gap in a scan is not itself a finding.
     notices: list[str] = field(default_factory=list)
 
 
@@ -43,10 +46,20 @@ def resolve_scope(args: argparse.Namespace, config: Config, project_dir: Path) -
     Discovery is opt-in (#97): with no ``[files]`` at all, every mode narrows to
     nothing and the run says why. A git mode still resolves its base ref first,
     so a typo'd ref fails loudly rather than being masked by an empty opt-in.
+
+    Two things are worth saying about a scope, and only one of them is about an
+    empty one: a submodule left out shrinks a scan that still has plenty to
+    measure, and unsaid it would render ✅ over the gap.
     """
-    picked = _selected(args, config, project_dir)
-    files = _source_files(picked, config, project_dir)
+    placed = _placed(_selected(args, config, project_dir), project_dir)
+    files = _source_files(placed, config, project_dir)
     notices = [] if files else empty_scope_notices(args.file, project_dir, config)
+    if args.file is None:
+        # Policy, not correctness: `submodule_paths` would identify a submodule
+        # given to `--file` perfectly well. But that mode answers about the one
+        # path the caller named, `_named_file_notice` already says a directory
+        # is not a file, and a second line about it would only repeat that.
+        notices = [*submodule_notices(placed, config, project_dir), *notices]
     return Scope(files, notices)
 
 
@@ -83,44 +96,41 @@ def _configured_scope(config: Config, project_dir: Path) -> list[str]:
     return _every_file(config, project_dir)
 
 
-def _source_files(paths: list[str], config: Config, project_dir: Path) -> list[str]:
+def _placed(paths: list[str], project_dir: Path) -> list[str]:
+    """Each path under the project's own name for it, dropping any outside it.
+
+    Split from the narrowing below because the notices need these too: a
+    submodule is recognised by being a directory, so it has to be recognised
+    before the step that keeps only files throws it away.
+    """
+    named = (project_relative(path, project_dir) for path in paths)
+    return [path for path in named if path]
+
+
+def _source_files(placed: list[str], config: Config, project_dir: Path) -> list[str]:
     """The paths a sensor can be asked about: files that are there, and are source.
 
-    All three narrowings belong here, not in each sensor: a path is placed in the
-    project (a hook hands ``--file`` an absolute path no relative glob matches);
-    one a branch deleted is dropped (a gone file has no smells left); and
-    ``[files]`` keeps only source, so a lockfile bump is out of a git-derived
-    scope as it is out of ``--all``. No ``[files]`` and an empty one keep nothing
-    (#97).
+    Both narrowings belong here, not in each sensor: a path a branch deleted is
+    dropped (a gone file has no smells left, and a submodule's own directory is
+    not a file either); and ``[files]`` keeps only source, so a lockfile bump is
+    out of a git-derived scope as it is out of ``--all``. No ``[files]`` and an
+    empty one keep nothing (#97).
     """
-    placed = (project_relative(path, project_dir) for path in paths)
-    present = [path for path in placed if path and (project_dir / path).is_file()]
+    present = [path for path in placed if (project_dir / path).is_file()]
     return matching(present, config.files or [])
 
 
-def matching(paths: list[str], globs: list[str]) -> list[str]:
-    """The ``paths`` kept by pathspec (gitignore) ``globs``, order preserved.
-
-    The one place a path list is filtered by a glob list: the run's ``[files]``
-    and a single sensor's own ``files`` narrowing in ``execution.py``.
-    """
-    spec = pathspec.PathSpec.from_lines("gitignore", globs)
-    return [path for path in paths if spec.match_file(path)]
-
-
 def _every_file(config: Config, project_dir: Path) -> list[str]:
-    """Every file under the project, once there is a ``[files]`` to narrow it to.
+    """Every file the project has, once there is a ``[files]`` to narrow it to.
 
-    Discovery is opt-in (#97): with none, nothing is enumerated — a default
-    install never walks ``node_modules`` or ``.venv`` only to discard the lot.
+    Discovery is opt-in (#97): with none, nothing is enumerated and git is never
+    asked — a default install must not walk ``node_modules`` only to discard it.
+    What counts as the project's own files, and why git rather than the disk
+    answers that, is ``project_scan``.
     """
     if config.files is None:
         return []
-    return sorted(
-        str(path.relative_to(project_dir))
-        for path in project_dir.rglob("*")
-        if path.is_file()
-    )
+    return project_scan.files_in(project_dir)
 
 
 def _with_work_in_progress(project_dir: Path, tracked: list[str]) -> list[str]:

--- a/src/habit_hooks/scope_notices.py
+++ b/src/habit_hooks/scope_notices.py
@@ -9,28 +9,102 @@ which there is more than there is code, has to stay consistent.
 Two shapes, one setting: a whole run that narrowed to nothing gets
 ``NO_FILES_NOTICE``, while ``--file`` keeps a per-file diagnosis (the hook behind
 it fires on every edit, including files a project rightly does not scan).
+
+A submodule is the one thing said about a scope that is *not* empty: the scan
+shrank without emptying, and the gap has to be named or the run renders ✅ over
+it. Every notice here is advisory — written to stderr, leaving the exit code to
+the findings — which is why a run that scanned nothing at all still exits 0.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from . import git_listing
 from .config import Config
+from .path_globs import matching
 from .project_paths import project_relative
 
 # Discovery is opt-in (#97): a project that names no source scans nothing.
 _NO_FILES = "no [files] are configured — name what to scan in .habit-hooks/config.toml"
 NO_FILES_NOTICE = f"habit-sensors: {_NO_FILES}; nothing scanned"
 
+# A `[files]` that is set and still kept nothing. Both halves of the cause are
+# named because neither is visible from the other: `[files]` may be too narrow,
+# or git may be ignoring the very tree it was written for.
+NOTHING_MATCHED_NOTICE = (
+    "habit-sensors: nothing matched [files] — check it in "
+    ".habit-hooks/config.toml, and whether git ignores the paths you expected; "
+    "nothing scanned"
+)
+
 
 def empty_scope_notices(
     named: str | None, project_dir: Path, config: Config
 ) -> list[str]:
     """Why a scope came out empty: the diagnosis for the one file ``--file``
-    named, else the whole run's. Only an empty scope is ever remarked on."""
+    named, else the whole run's. Only an empty scope is ever remarked on.
+
+    **Every** empty scope says something, and that is the point. A ``[files]``
+    that is set and matched nothing used to be the one silent case, so a project
+    whose ``.gitignore`` covered its own source tree scanned zero files and
+    rendered ✅ — a run that *measured* nothing, indistinguishable from a run
+    that *found* nothing, which is the #88 class this tool exists to prevent.
+    """
     if named is not None:
         return [_named_file_notice(named, project_dir, config)]
-    return [NO_FILES_NOTICE] if config.files is None else []
+    return [NO_FILES_NOTICE if config.files is None else NOTHING_MATCHED_NOTICE]
+
+
+def submodule_notices(placed: list[str], config: Config, project_dir: Path) -> list[str]:
+    """One line per submodule this run would have measured inside, had it looked.
+
+    Git names a submodule by its own directory and never by the files inside it,
+    so a vendored subtree drops out of a scan. That is the right answer — every
+    git-derived mode was always blind to one, and the submodule gates itself in
+    its own repository — but a scope that quietly shrinks and then renders ✅ is
+    the false clean this whole tool exists to stop. The partial case is the
+    dangerous one: a project with its own ``src/`` goes on reporting about the
+    rest and says nothing at all about what it skipped.
+
+    **This module owns the whole decision**, both halves of it, because a notice
+    that is right about one half and wrong about the other is worse than none.
+    ``git_listing`` answers what a submodule *is* and ``scope`` owns the
+    narrowing, so splitting the judgement between them would leave neither able
+    to state the thing being claimed: that this run lost source it wanted.
+
+    ``placed`` is what keeps a git-derived mode quiet about a submodule its own
+    commits never touched: ``--last 1`` picks the paths that changed, and a
+    submodule absent from them is not something that run left out. Without it
+    every scoped run would announce every submodule the project has.
+    """
+    if not config.files:
+        return []  # opting out of discovery is answered before any git call
+    picked = set(placed)
+    return [
+        f"habit-sensors: {path} is a submodule; its files are scanned in "
+        "their own repository"
+        for path in git_listing.submodule_paths(project_dir)
+        if path in picked and _held_source_this_run_wanted(path, config, project_dir)
+    ]
+
+
+def _held_source_this_run_wanted(
+    submodule: str, config: Config, project_dir: Path
+) -> bool:
+    """Whether ``[files]`` would have kept anything the submodule holds.
+
+    A project whose ``[files]`` already excludes the directory lost nothing by
+    it being skipped, and telling it otherwise states something false about its
+    own scan. The typescript plugin's ``!**/node_modules/**`` is the case: the
+    scan is exactly the size that project expects, so there is nothing to say.
+
+    Asked by listing what the submodule really holds rather than by matching its
+    directory name, because a source glob (``**/*.py``) never matches a bare
+    directory — so testing the name would silence every notice there is.
+    """
+    held = git_listing.project_files(project_dir / submodule)
+    return bool(matching([f"{submodule}/{path}" for path in held], config.files or []))
 
 
 def _named_file_notice(named: str, project_dir: Path, config: Config) -> str:

--- a/src/habit_hooks/sensors/diagnosis.py
+++ b/src/habit_hooks/sensors/diagnosis.py
@@ -21,6 +21,26 @@ from __future__ import annotations
 # guaranteed to be the one part carrying no diagnosis.
 DIAGNOSIS_LINE_LIMIT = 20
 
+# How much of any single line survives, split the same way. Counting lines
+# alone bounds a tool that is chatty and not one that is terse: a report from
+# ``eslint -f json`` is ONE line however many megabytes it holds, so it clears
+# a twenty-line budget without shedding a byte.
+#
+# Generous enough for every diagnosis a wrapped tool writes for a human to read.
+# Measured, longest stderr line on a real failure: pmd 273, eslint 221, deptry
+# 207, ruff 199, a Node stack frame 170, a Python traceback frame 154, knip 76,
+# ``command not found`` 42. This tool's own longest refusal is around 400.
+#
+# What it does cut is a machine-readable report a helper forwards when its tool
+# said nothing else — phpmd answers a parse error with JSON whose ``message``
+# carries a whole escaped PHP stack trace, one line of nearly 7,000 characters.
+# Cutting that is the point, and both ends of it survive: the file and position
+# are in the first 200 characters and ``#23 {main}`` is at the end.
+#
+# The two limits together cap a notice at about 20,000 characters — which is
+# three to four times that in bytes once a tool complains in CJK or emoji.
+DIAGNOSIS_LINE_LENGTH_LIMIT = 1_000
+
 
 def as_text(output: str | bytes | None) -> str:
     """A killed part's output as text, whatever the spawn was told to decode.
@@ -45,16 +65,44 @@ def keep_both_ends(diagnosis: str) -> str:
     a tail too means the punchline survives whichever end of the output it
     landed on.
 
+    A line too long for its own budget is cut the same way, for the same
+    reason, once the surviving lines are chosen — a tool can be verbose in
+    either direction and one of them is a single enormous line.
+
     Truncating is only worth doing when it produces something shorter than what
-    it replaces: the excerpt is the head, the elision line standing in for what
-    it hides, and the tail, so it earns its place only once that is fewer lines
-    than the input it would replace.
+    it replaces: an excerpt is the head, the elision standing in for what it
+    hides, and the tail, so it earns its place only once that is smaller than
+    the input it would replace. Both cuts obey that, which is also what keeps
+    the elision's count from ever being small enough to read as ``1 lines``.
     """
     lines = diagnosis.splitlines()
+    kept = [_both_ends_of(line) for line in _the_lines_worth_keeping(lines)]
+    return diagnosis if kept == lines else "\n".join(kept)
+
+
+def _the_lines_worth_keeping(lines: list[str]) -> list[str]:
+    """Both ends of ``lines``, or all of them when eliding would not be shorter.
+
+    Chosen before any line is cut down, so a stderr of megabytes costs one pass
+    to slice rather than a second copy of itself to shorten — the input this
+    whole module exists to bound is exactly the one where that matters.
+    """
     head = DIAGNOSIS_LINE_LIMIT // 2
     tail = DIAGNOSIS_LINE_LIMIT - head
     omitted = len(lines) - head - tail
     excerpt = [*lines[:head], f"... {omitted} lines omitted ...", *lines[-tail:]]
-    if len(excerpt) < len(lines):
-        return "\n".join(excerpt)
-    return diagnosis
+    return excerpt if len(excerpt) < len(lines) else lines
+
+
+def _both_ends_of(line: str) -> str:
+    """One line cut to its budget, by the same rule and for the same reason.
+
+    Where the punchline lands is no more predictable within a line than across
+    them — a tool that appends its real complaint to a dump of what it was
+    reading puts it at the very end — so this keeps both ends here too.
+    """
+    head = DIAGNOSIS_LINE_LENGTH_LIMIT // 2
+    tail = DIAGNOSIS_LINE_LENGTH_LIMIT - head
+    omitted = len(line) - head - tail
+    excerpt = f"{line[:head]}... {omitted} characters omitted ...{line[-tail:]}"
+    return excerpt if len(excerpt) < len(line) else line

--- a/src/habit_hooks/sensors/execution.py
+++ b/src/habit_hooks/sensors/execution.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..argv_budget import argument_budget, argument_cost, within_argument_limits
-from ..scope import Scope, matching
+from ..path_globs import matching
+from ..scope import Scope
 from .broken_part import run_part
 from .command_text import expanded, spelled_files, spells
 from .deadline import DEFAULT_SENSOR_TIMEOUT_SECONDS

--- a/tests/git_repo.py
+++ b/tests/git_repo.py
@@ -1,8 +1,10 @@
-"""Build the small git repositories the changed-file tests ask questions about.
+"""Build the small git repositories the changed-file and scope tests ask
+questions about.
 
 Every case here needs the same thing: a real repository, on a known branch, with
 something committed to compare against. This module only builds those; what a
-run must then conclude from them lives in ``test_changed_files.py``.
+run must then conclude from them lives in ``test_changed_files.py`` and the
+``test_a_scan_*`` modules.
 """
 
 from __future__ import annotations
@@ -10,22 +12,105 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def git(project_dir: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=project_dir, check=True, capture_output=True)
 
 
-def repository_with_committed_file(project_dir: Path) -> Path:
-    """A one-commit repository on ``main``; returns its committed file."""
-    committed = project_dir / "src.py"
-    committed.write_text("VALUES = [1]\n", encoding="utf-8")
+def stop_the_upward_walk_at(directory: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Git's search for a repository stops at ``directory``, so a case can only
+    ever see the repository it built for itself.
+
+    Without a ceiling, a case that shells out to git in a directory of its own
+    is answered about whatever repository lies above — this checkout, when the
+    case runs inside it. That is not hypothetical: a case doing exactly this
+    renamed this repository's ``main`` branch while proving an unrelated point.
+    """
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(directory))
+
+
+def repository(project_dir: Path, ignoring: str = "") -> Path:
+    """An empty repository at ``project_dir``, on ``main``, able to commit.
+
+    A ``.gitignore`` is written only when ``ignoring`` asks for one: an empty
+    file is itself a file, and would join the answer to every question about
+    what this project holds.
+    """
+    project_dir.mkdir(parents=True, exist_ok=True)
     git(project_dir, "init", "-q", "-b", "main", ".")
     git(project_dir, "config", "user.email", "spec@example.com")
     git(project_dir, "config", "user.name", "Spec Runner")
     git(project_dir, "config", "commit.gpgsign", "false")
+    if ignoring:
+        (project_dir / ".gitignore").write_text(ignoring, encoding="utf-8")
+    return project_dir
+
+
+def repository_with_committed_file(project_dir: Path) -> Path:
+    """A one-commit repository on ``main``; returns its committed file."""
+    committed_file = project_dir / "src.py"
+    committed_file.write_text("VALUES = [1]\n", encoding="utf-8")
+    repository(project_dir)
     git(project_dir, "add", "src.py")
     git(project_dir, "commit", "-q", "-m", "baseline")
-    return committed
+    return committed_file
+
+
+def written(file: Path) -> Path:
+    """A source file at ``file``, and the directories to reach it."""
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text("x = 1\n", encoding="utf-8")
+    return file
+
+
+def committed(project_dir: Path, file: Path) -> Path:
+    """``file`` written and committed to the repository at ``project_dir``.
+
+    ``--force`` so a case can put a file into the index that the repository's own
+    rules ignore, which is a scope question all of its own.
+    """
+    written(file)
+    git(project_dir, "add", "--force", str(file.relative_to(project_dir)))
+    git(project_dir, "commit", "-q", "-m", f"add {file.name}")
+    return file
+
+
+def submodule(project_dir: Path, inner: Path, at: str) -> Path:
+    """``inner`` checked out inside ``project_dir`` at ``at``, and committed.
+
+    ``protocol.file.allow`` lifts git's own refusal to clone a submodule over a
+    local path (CVE-2022-39253), which is the only kind of source a test has.
+    """
+    git(
+        project_dir,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "--quiet",
+        "add",
+        inner.as_posix(),
+        at,
+    )
+    git(project_dir, "commit", "-q", "-m", f"vendor {at}")
+    return project_dir / at
+
+
+def tracked_symlink(project_dir: Path, at: str, target: Path) -> Path:
+    """A symlink at ``at`` pointing to ``target``, tracked by the repository.
+
+    Git records one with mode ``120000``, never the ``160000`` of a submodule —
+    but on disk it answers ``is_dir()`` exactly as a submodule does. A symlinked
+    ``node_modules`` is pnpm's ordinary layout, so this is the everyday shape
+    that any filesystem-based test for a submodule gets wrong.
+    """
+    link = project_dir / at
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target)
+    git(project_dir, "add", at)
+    git(project_dir, "commit", "-q", "-m", f"link {at}")
+    return link
 
 
 def commit_file(file: Path, body: str) -> None:

--- a/tests/platform_probe.py
+++ b/tests/platform_probe.py
@@ -26,6 +26,14 @@ rather than decided anywhere in this tool, so there is no seam ``on_windows``
 could flip. The two hosts answer for themselves, and each half of the story
 runs on the one that can tell it.
 
+Whether a process can be *signalled* is that kind of question too. POSIX ends
+one with a signal, so the parent reads ``status: null, signal: "SIGKILL"``;
+Windows has no signals at all, and Node's ``process.kill`` there calls
+``TerminateProcess``, leaving an ordinary ``status: 1`` and no signal — which is
+the very shape a successful findings run has. Nothing in this tool decides
+that, so there is no seam to flip: each host answers for itself, and each half
+of the story runs on the one that can tell it.
+
 ``A_MACHINE_THAT_CAN_MAKE_A_SYMLINK`` is the same kind of question one step
 further out: not what platform this is, but what this account is *allowed* to
 do on it. Windows grants symlink creation to an administrator and to Developer
@@ -83,6 +91,16 @@ def _symlinks_are_permitted_here() -> bool:
             return False
         return True
 
+
+A_MACHINE_WITH_SIGNALS = pytest.mark.skipif(
+    os.name == "nt",
+    reason="a killed process only carries a signal where the platform has them",
+)
+
+A_MACHINE_WITHOUT_SIGNALS = pytest.mark.skipif(
+    os.name != "nt",
+    reason="only Windows ends a process with TerminateProcess, leaving an exit code",
+)
 
 A_MACHINE_THAT_CAN_MAKE_A_SYMLINK = pytest.mark.skipif(
     not _symlinks_are_permitted_here(),

--- a/tests/platform_probe.py
+++ b/tests/platform_probe.py
@@ -26,6 +26,13 @@ rather than decided anywhere in this tool, so there is no seam ``on_windows``
 could flip. The two hosts answer for themselves, and each half of the story
 runs on the one that can tell it.
 
+``A_MACHINE_THAT_CAN_MAKE_A_SYMLINK`` is the same kind of question one step
+further out: not what platform this is, but what this account is *allowed* to
+do on it. Windows grants symlink creation to an administrator and to Developer
+Mode and to nobody else, so the two Windows machines disagree with each other —
+which is why it is settled by trying it once here rather than by reading
+``os.name``, and why a machine that can do it runs the case wherever it is.
+
 The recorders below stand in for the two ways a command is ended. Neither can be
 let run: ``os.killpg`` would signal a real process group — pid 4321 is somebody
 — and ``taskkill`` does not exist off Windows at all.
@@ -35,6 +42,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -54,6 +63,35 @@ A_MACHINE_THAT_SPELLS_A_COMMAND_ITSELF = pytest.mark.skipif(
 A_MACHINE_THAT_DOES_NOT = pytest.mark.skipif(
     os.name == "nt",
     reason="everywhere else a command is the filename it is, and a shebang runs",
+)
+
+
+def _symlinks_are_permitted_here() -> bool:
+    """Whether this machine will let a test create a symlink at all.
+
+    Tried rather than inferred. Windows needs ``SeCreateSymbolicLinkPrivilege``
+    to make one — held by an administrator, and by any account with Developer
+    Mode switched on, but by nobody else — so ``os.name`` answers the wrong
+    question twice over: it would skip a privileged Windows machine that can
+    run the case perfectly well, and it says nothing about a POSIX filesystem
+    that refuses one.
+    """
+    with tempfile.TemporaryDirectory() as scratch:
+        try:
+            Path(scratch, "probe").symlink_to(scratch)
+        except (OSError, NotImplementedError):
+            return False
+        return True
+
+
+A_MACHINE_THAT_CAN_MAKE_A_SYMLINK = pytest.mark.skipif(
+    not _symlinks_are_permitted_here(),
+    reason=(
+        "creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows, so "
+        "a symlinked node_modules — pnpm's ordinary layout, and the shape issue "
+        "#142 came from — is unmeasured on a machine without it (see #137 for "
+        "why a platform gap is skipped out loud rather than passed over)"
+    ),
 )
 
 

--- a/tests/sensor_notice.py
+++ b/tests/sensor_notice.py
@@ -1,0 +1,44 @@
+"""The notice a broken sensor leaves on its failed run.
+
+Shared by the two suites that read one back: which failure it describes
+(``test_part_output.py``) and how much of the tool's own words come with it
+(``test_how_much_a_failure_says.py``) — the same line ``part_output.py`` and
+``diagnosis.py`` are themselves split along.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from habit_hooks.scope import Scope
+from habit_hooks.sensors.execution import Execution
+from habit_hooks.sensors.model import Part
+
+
+def sensor_notice(tmp_path: Path, command: str) -> str:
+    """The one notice a sensor running ``command`` leaves on its failed run."""
+    return only_notice(Part(name="probe", command=command, directory=tmp_path), tmp_path)
+
+
+def script_notice(tmp_path: Path, script: str) -> str:
+    """The one notice a sensor running python ``script`` leaves on its failed run.
+
+    No shell is needed for what these tests prove — how a broken part's own
+    output is quoted back — so this spells an ``argv`` part, unlike the real
+    shell's own ``command not found`` diagnosis ``sensor_notice`` above needs.
+    """
+    (tmp_path / "probe.py").write_text(script, encoding="utf-8")
+    part = Part(name="probe", directory=tmp_path, argv=["${python}", "${dir}/probe.py"])
+    return only_notice(part, tmp_path)
+
+
+def only_notice(part: Part, project_dir: Path) -> str:
+    """The one notice ``part`` leaves on the failed run it produces."""
+    execution = Execution(project_dir=project_dir, scope=Scope(files=["src/a.py"]))
+
+    run = execution.run_sensors([part])
+
+    assert run.findings == []
+    assert run.failed
+    assert len(run.notices) == 1
+    return run.notices[0]

--- a/tests/test_a_runner_nobody_installed_is_named.py
+++ b/tests/test_a_runner_nobody_installed_is_named.py
@@ -1,0 +1,63 @@
+"""A `[runners]` command that is not installed answers in one line.
+
+``[runners]`` lets a project route a smell to an executable guide instead of a
+Markdown one. Naming a command nobody has is a first-contact mistake — a typo,
+or a tool the reader has yet to install — and #114's rule is that those answer
+with a sentence rather than a Python stack trace. That sweep covered the sensors
+stage; the mapper's fix runner was left out, so a missing runner escaped as a
+`FileNotFoundError` through `cli.run_console`, which catches only `ToolError`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from habit_hooks import mapper
+from habit_hooks.cli import ToolError
+from plugin_fixture import write_plugin, write_project_config
+
+_FINDING = {
+    "smell": "oversized-file",
+    "details": {},
+    "issues": [{"key": "src/a.py", "details": {"file": "src/a.py"}}],
+}
+
+
+def _project_routing_to(tmp_path: Path, runner: str) -> Path:
+    write_plugin(
+        tmp_path,
+        "fixt",
+        {"config.toml": "", "guides/oversized-file.sh": "echo fixed\n"},
+    )
+    write_project_config(
+        tmp_path, f'plugins = ["fixt"]\n[runners]\nsh = "{runner}"'
+    )
+    return tmp_path
+
+
+def test_a_runner_that_is_not_installed_is_named_with_what_to_do(
+    tmp_path: Path,
+) -> None:
+    """The refusal names the command, the guide that asked for it, and the way out."""
+    project = _project_routing_to(tmp_path, "a-runner-nobody-installed")
+
+    with pytest.raises(ToolError) as refusal:
+        mapper.run([_FINDING], project)
+
+    said = str(refusal.value)
+    assert "a-runner-nobody-installed" in said
+    assert "oversized-file.sh" in said
+    assert "Traceback" not in said
+
+
+def test_a_runner_that_is_installed_still_runs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The guard answers for a command that is absent, and for nothing else."""
+    project = _project_routing_to(tmp_path, "sh")
+
+    mapper.run([_FINDING], project)
+
+    assert "fixed" in capsys.readouterr().out

--- a/tests/test_a_scan_git_cannot_answer_for.py
+++ b/tests/test_a_scan_git_cannot_answer_for.py
@@ -1,0 +1,166 @@
+"""When a whole-project scan must not believe git, and walks the disk instead.
+
+Since #142 a whole-project scan measures the files git says the project keeps,
+rather than every file on disk. That is the right answer only where git is the
+right thing to ask, and there are three places it is not: a project the
+surrounding repository ignores outright, a project in no repository at all, and
+a machine with no git on it. In each, git's answer is empty or partial while the
+project plainly has files — so the tree walk answers instead.
+
+The direction matters. A run that over-scans is a nuisance; a run that scans
+nothing reports a whole tree clean without opening a single file, which is the
+false-clean this tool exists to prevent. What a scan measures when git *can*
+answer is ``test_a_scan_skips_what_git_ignores.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git_repo import committed, git, repository, stop_the_upward_walk_at, written
+from habit_hooks import git_listing, project_scan
+from habit_hooks.config import Config
+from scope_probe import scoped_files as _scoped_files
+
+# Discovery is opt-in since #97: a case must name its source before any mode
+# enumerates anything.
+_PY_SOURCE = ["**/*.py"]
+
+
+@pytest.fixture(autouse=True)
+def _only_the_repository_the_case_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop_the_upward_walk_at(tmp_path, monkeypatch)
+
+
+def test_a_project_in_somebody_elses_ignored_tree_scans_everything(
+    tmp_path: Path,
+) -> None:
+    """A project can sit inside a directory the repository around it ignores.
+
+    Git then calls every file in that project ignored, because the rule covering
+    the project directory covers everything beneath it. That rule was never about
+    this project, so it decides nothing about it. This repository is its own
+    example: its spec cases run inside a ``.spec-runs/`` its ``.gitignore``
+    covers, and each case is a real project whose files are all in scope.
+    """
+    above = repository(tmp_path / "repo", ignoring="runs/\n")
+    project = above / "runs" / "case"
+    written(project / "a.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["a.py"]
+
+
+def test_one_force_tracked_file_never_becomes_an_ignored_projects_whole_scope(
+    tmp_path: Path,
+) -> None:
+    """The case that makes the guard worth having, rather than merely harmless.
+
+    An outer repository can track a file *under* a path it ignores, by
+    force-adding it. Git then lists that one file for the project and nothing
+    else. A partial list is far more dangerous than an empty one: falling back to
+    the disk when git says *nothing* never catches it, so the run would measure
+    one file and pronounce every other file clean without reading it.
+
+    Asking whether the directory is ignored has to ignore the index to see this
+    — by default git calls a directory holding tracked content "not ignored".
+    """
+    above = repository(tmp_path / "repo", ignoring="runs/\n")
+    project = above / "runs" / "case"
+    committed(above, project / "tracked.py")
+    written(project / "unseen.py")
+
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == [
+        "tracked.py",
+        "unseen.py",
+    ]
+
+
+def test_the_tree_walk_spells_a_nested_path_the_way_git_does(tmp_path: Path) -> None:
+    """The fallback has to be a drop-in for git's answer, separators included.
+
+    Git names a nested file ``src/a.py`` on every platform. The walk builds its
+    own string from ``os.sep``, which is a backslash on Windows — and ``\\``
+    and ``/`` sort differently, so the ``sorted()`` inside ``files_in`` would
+    order the same project one way from git and another from the walk. No
+    caller sees the backslash itself (``scope._placed`` normalises again), so
+    what is at stake is the two branches being interchangeable.
+
+    Asserted outright rather than by comparing the branches: on a Mac ``os.sep``
+    is already ``/``, so a comparison passes whether or not anything normalises
+    and reads its expected answer off the host. Only the Windows leg can tell
+    these apart, and this is the assertion it runs.
+    """
+    project = tmp_path / "project"
+    written(project / "src" / "a.py")
+    assert project_scan.files_in(project) == ["src/a.py"]
+
+
+def test_a_project_outside_a_repository_scans_everything(tmp_path: Path) -> None:
+    """No repository, so nothing ignores anything and the tree walk still answers."""
+    project = tmp_path / "project"
+    written(project / "a.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == [
+        "a.py",
+        "dist/built.py",
+    ]
+
+
+def test_a_machine_with_no_git_scans_everything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Git's silence never means "nothing to scan". With no git to ask, the tree
+    walk answers in full — including the files a present git would have call
+    ignored, because nothing is left that could say so."""
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    written(project / "a.py")
+    written(project / "dist" / "built.py")
+    monkeypatch.setenv("PATH", str(written(tmp_path / "bin" / "keep.py").parent))
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == [
+        "a.py",
+        "dist/built.py",
+    ]
+
+
+def test_a_project_with_no_files_setting_asks_git_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery stays opt-in (#97), and opting out is answered before any git
+    call: a default install spawns no process only to discard every path it
+    named.
+
+    All three doors are held, because each was opened separately and the third
+    (``submodule_paths``, for the scope notices) was added long after the first
+    two and spawned ``ls-files --stage`` over a whole monorepo index before
+    deciding to scan nothing.
+    """
+
+    def _never_asked(*_args: object) -> object:
+        raise AssertionError("git was asked about a project with no [files]")
+
+    monkeypatch.setattr(git_listing, "ignores_directory", _never_asked)
+    monkeypatch.setattr(git_listing, "project_files", _never_asked)
+    monkeypatch.setattr(git_listing, "submodule_paths", _never_asked)
+    project = repository(tmp_path / "project")
+    written(project / "a.py")
+    assert _scoped_files(["--all"], project, Config()) == []
+
+
+def test_a_repository_git_cannot_be_asked_about_still_places_its_files(
+    tmp_path: Path,
+) -> None:
+    """A repository whose index git refuses to read answers nothing at all, and
+    that failure must degrade to the disk exactly as a missing git does — not to
+    an empty scope, which would read as a clean tree."""
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    written(project / "a.py")
+    written(project / "dist" / "built.py")
+    git(project, "add", "a.py")
+    (project / ".git" / "index").write_bytes(b"not an index")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == [
+        "a.py",
+        "dist/built.py",
+    ]

--- a/tests/test_a_scan_names_the_submodules_it_skipped.py
+++ b/tests/test_a_scan_names_the_submodules_it_skipped.py
@@ -1,0 +1,169 @@
+"""What a whole-project scan says about the submodules it cannot look inside.
+
+A submodule is another repository checked out within this one. Git names it by
+its own directory and never by the files in it, so its source leaves the scan —
+rightly, since every git-derived mode was always blind to one and the submodule
+gates itself in its own repository. But a scope that quietly shrinks and then
+renders ✅ is the false clean this tool exists to stop, so the run names each
+submodule whose files it would otherwise have measured.
+
+These cases decide **when the line is worth printing**: it is, when the run
+would otherwise have measured files inside; it is not, when ``[files]`` excluded
+the directory anyway, nor when a git-derived mode's own commits never touched it.
+
+Telling a submodule from a symlink or an ordinary directory in the first place is
+``test_what_counts_as_a_submodule.py``; which files a scan measures at all is
+``test_a_scan_skips_what_git_ignores.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git_repo import committed, repository, stop_the_upward_walk_at, submodule
+from habit_hooks import project_scan
+from habit_hooks.config import Config
+from scope_probe import scope as _scope
+from scope_probe import scoped_files as _scoped_files
+
+# Discovery is opt-in since #97: a case must name its source before any mode
+# enumerates anything.
+_PY_SOURCE = ["**/*.py"]
+
+
+@pytest.fixture(autouse=True)
+def _only_the_repository_the_case_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop_the_upward_walk_at(tmp_path, monkeypatch)
+
+
+def _vendoring_a_submodule(tmp_path: Path) -> Path:
+    """A project with source of its own and another repository checked out at
+    ``vendor/lib``, which holds source matching the same ``[files]``."""
+    inner = repository(tmp_path / "lib")
+    committed(inner, inner / "inner.py")
+    project = repository(tmp_path / "project")
+    committed(project, project / "own.py")
+    submodule(project, inner, "vendor/lib")
+    return project
+
+
+def test_a_submodules_source_is_not_this_projects_to_scan(tmp_path: Path) -> None:
+    """A submodule — another repository checked out inside this one — is named by
+    git as a single directory entry, never as the files inside it.
+
+    So its source leaves a whole-project scan, which is what every git-derived
+    mode already did with it: ``git diff`` names the same lone directory and does
+    not descend either. The submodule gates itself, in its own repository.
+    """
+    project = _vendoring_a_submodule(tmp_path)
+    assert (project / "vendor" / "lib" / "inner.py").is_file()
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["own.py"]
+
+
+def test_a_submodule_left_out_of_a_partial_scan_is_named(tmp_path: Path) -> None:
+    """The dangerous shape: the scan still has plenty to measure, so it reports
+    on the rest and renders ✅ — over a subtree it never opened.
+
+    Dropping a submodule is right, but doing it silently is the false clean this
+    tool exists to stop, so the run says which subtree went missing.
+    """
+    project = _vendoring_a_submodule(tmp_path)
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == ["own.py"]
+    assert scanned.notices == [
+        "habit-sensors: vendor/lib is a submodule; its files are scanned in "
+        "their own repository"
+    ]
+
+
+def test_a_submodule_is_named_even_when_it_emptied_the_scan(tmp_path: Path) -> None:
+    """A project that is nothing but vendored submodules scans no file at all.
+
+    The empty-scope notice explains a missing ``[files]`` and would say nothing
+    here, because ``[files]`` is present and correct — so without this the run
+    is a bare ✅ over a repository whose every source file was skipped.
+    """
+    inner = repository(tmp_path / "lib")
+    committed(inner, inner / "inner.py")
+    project = repository(tmp_path / "project")
+    committed(project, project / "README.md")
+    submodule(project, inner, "vendor/lib")
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == []
+    assert "vendor/lib is a submodule" in "\n".join(scanned.notices)
+
+
+def test_a_submodule_no_files_setting_wanted_is_not_mentioned(tmp_path: Path) -> None:
+    """The notice claims "your scan is smaller than you think" — so it must not
+    fire where the scan is exactly the size the project asked for.
+
+    A project excluding the directory outright loses nothing by its being
+    skipped. ``!**/vendor/**`` here is the shape of the typescript plugin's own
+    ``!**/node_modules/**``, which made a real run announce a gap it did not have.
+    """
+    project = _vendoring_a_submodule(tmp_path)
+    excluded = Config(files=["**/*.py", "!**/vendor/**"])
+
+    assert _scope(["--all"], project, excluded).notices == []
+    assert _scope(["--all"], project, Config(files=_PY_SOURCE)).notices != []
+
+
+def test_a_submodules_own_entry_cannot_reach_a_sensor(tmp_path: Path) -> None:
+    """The entry git *does* name for a submodule is a directory on disk, and a
+    sensor handed it would die opening it rather than reading a file.
+
+    Nothing keeps it out but the narrowing to files that exist, so that is what
+    this measures: ``[files]`` here matches the entry and nothing else, which
+    rules the glob out as the reason. The scan still ends up with no files at
+    all — never with a directory dressed as one.
+    """
+    project = _vendoring_a_submodule(tmp_path)
+    assert "vendor/lib" in project_scan.files_in(project)
+    assert (project / "vendor" / "lib").is_dir()
+    assert _scoped_files(["--all"], project, Config(files=["vendor/**"])) == []
+
+
+
+
+def test_a_submodule_at_a_non_ascii_path_is_still_named(tmp_path: Path) -> None:
+    """``-z`` on ``ls-files --stage`` keeps ``café/lib`` a path git named.
+
+    Quoted back as ``"caf\\303\\251/lib"`` it matches nothing the scope picked,
+    so the submodule is silently never mentioned — the gap goes unannounced for
+    exactly the projects whose paths are hardest to spell.
+    """
+    inner = repository(tmp_path / "lib")
+    committed(inner, inner / "inner.py")
+    project = repository(tmp_path / "project")
+    committed(project, project / "own.py")
+    submodule(project, inner, "café/lib")
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == ["own.py"]
+    assert scanned.notices == [
+        "habit-sensors: café/lib is a submodule; its files are scanned in "
+        "their own repository"
+    ]
+
+
+def test_a_git_mode_is_silent_about_a_submodule_it_never_touched(
+    tmp_path: Path,
+) -> None:
+    """A scoped run answers about what changed, so a submodule its commits never
+    moved is not something it left out.
+
+    Without that, every ``--last 1`` in a repository with a submodule would
+    announce it — on a pre-commit hook, on every commit, for ever.
+    """
+    project = _vendoring_a_submodule(tmp_path)
+    committed(project, project / "later.py")
+    scanned = _scope(["--last", "1"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == ["later.py"]
+    assert scanned.notices == []

--- a/tests/test_a_scan_skips_what_git_ignores.py
+++ b/tests/test_a_scan_skips_what_git_ignores.py
@@ -1,0 +1,138 @@
+"""What a whole-project scan measures: the files the project keeps, not every
+file on disk (#142).
+
+``--all`` walked the directory tree, so it measured build output, caches and
+``.next/`` — while ``--last 1`` and every other git-derived mode, which ask git,
+never did. One project, two universes: a real pnpm monorepo held 321 tracked
+``.ts``/``.tsx`` files and 843 on disk, and its owner had to hand-write
+``!**/dist/**`` into ``[files]`` before a run was usable. A default somebody has
+to patch is the wrong default.
+
+These are the cases where git's answer is the one taken. When git is the wrong
+thing to ask — the project itself ignored, no repository, no git at all — the
+disk still answers, and that is ``test_a_scan_git_cannot_answer_for.py``. What a
+scan then *says* about a submodule it stepped over is
+``test_a_scan_names_the_submodules_it_skipped.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git_repo import committed, repository, stop_the_upward_walk_at, written
+from habit_hooks.config import Config, ScopeDefaults
+from scope_probe import scoped_files as _scoped_files
+
+# Discovery is opt-in since #97: a case must name its source before any mode
+# enumerates anything.
+_PY_SOURCE = ["**/*.py"]
+
+
+@pytest.fixture(autouse=True)
+def _only_the_repository_the_case_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop_the_upward_walk_at(tmp_path, monkeypatch)
+
+
+def test_an_ignored_file_is_out_of_a_whole_project_scan(tmp_path: Path) -> None:
+    """The bug itself: build output the project told git to forget was scanned."""
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    committed(project, project / "src" / "a.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["src/a.py"]
+
+
+def test_a_repository_above_the_project_still_ignores_for_it(tmp_path: Path) -> None:
+    """A project in a subdirectory is governed by the repository it sits in: the
+    root ``.gitignore`` decides, and git answers about the subdirectory in the
+    subdirectory's own terms rather than the repository root's."""
+    above = repository(tmp_path / "repo", ignoring="build/\n")
+    project = above / "pkg"
+    committed(above, project / "keep.py")
+    written(project / "build" / "generated.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["keep.py"]
+
+
+def test_a_brand_new_untracked_file_is_still_in_scope(tmp_path: Path) -> None:
+    """The file most likely to carry a fresh smell is the one just written and
+    never added, so "what git keeps" has to mean tracked *and* not-yet-tracked.
+    Narrowing to the index alone would be a worse bug than the one being fixed.
+    """
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    written(project / "fresh.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["fresh.py"]
+
+
+def test_a_non_ascii_name_survives_gits_answer(tmp_path: Path) -> None:
+    """``-z`` is what keeps ``café.py`` a filename: quoted back as
+    ``"caf\\303\\251.py"`` it names nothing on disk and is dropped, so the file
+    would silently leave the scope the moment git started answering for it."""
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    committed(project, project / "café.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["café.py"]
+
+
+def test_the_configured_scope_filters_as_all_does(tmp_path: Path) -> None:
+    """Every mode that reaches the whole-project walk gets the same answer: a run
+    with no flags at all, on the main branch, is that walk under another name."""
+    project = repository(tmp_path / "project", ignoring="dist/\n")
+    committed(project, project / "src" / "a.py")
+    written(project / "dist" / "built.py")
+    config = Config(files=_PY_SOURCE, scope=ScopeDefaults(mainBranch="main"))
+    assert _scoped_files([], project, config) == ["src/a.py"]
+
+
+def test_files_still_narrows_what_git_keeps(tmp_path: Path) -> None:
+    """``[files]`` decides what counts as source, on top of git's answer: a
+    tracked, un-ignored file the project never called source stays out."""
+    project = repository(tmp_path / "project")
+    committed(project, project / "src" / "a.py")
+    committed(project, project / "README.md")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["src/a.py"]
+
+
+def test_a_file_deleted_from_the_work_tree_is_still_dropped(tmp_path: Path) -> None:
+    """Git keeps naming a tracked file the work tree no longer has, and a gone
+    file has no smells left — the narrowing that already dropped it must still
+    run after git's answer replaces the tree walk."""
+    project = repository(tmp_path / "project")
+    committed(project, project / "src" / "a.py").unlink()
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == []
+
+
+def test_a_project_whose_own_gitignore_starts_with_a_star(tmp_path: Path) -> None:
+    """The allow-list shape — ``*`` then exceptions — is a common way to write a
+    ``.gitignore``, and it used to switch this whole fix off.
+
+    The guard asked ``check-ignore .``, and ``*`` matches the name ``.`` as
+    readily as any other, so a project reported *itself* ignored and its own
+    file list was thrown away for the disk walk. A repository never ignores its
+    own root, so that is settled before the ignore rules are consulted at all.
+    """
+    project = repository(tmp_path / "project", ignoring="*\n!.gitignore\n!keep.py\n")
+    committed(project, project / "keep.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["keep.py"]
+
+
+def test_a_nested_project_whose_own_gitignore_starts_with_a_star(
+    tmp_path: Path,
+) -> None:
+    """The same pattern one directory down, where the root check cannot help.
+
+    ``pkg`` is not a repository root, so the ignore rules really are asked — and
+    asked about ``.`` they are the project's *own* ``*``, which says nothing
+    about what the repository above thinks of ``pkg``. Naming the directory in
+    full is what puts the question to the right pattern.
+    """
+    above = repository(tmp_path / "repo")
+    project = above / "pkg"
+    written(project / ".gitignore").write_text("*\n!keep.py\n", encoding="utf-8")
+    committed(above, project / "keep.py")
+    written(project / "dist" / "built.py")
+    assert _scoped_files(["--all"], project, Config(files=_PY_SOURCE)) == ["keep.py"]

--- a/tests/test_a_sensors_own_issues_are_never_second_guessed.py
+++ b/tests/test_a_sensors_own_issues_are_never_second_guessed.py
@@ -1,0 +1,140 @@
+"""A sensor's own issue list survives the merge exactly as it arrived.
+
+#140 is about two *sensors* reporting one observation, so deduplication happens
+only when a later finding is folded into an earlier one. Within a single
+finding nothing is dropped: the sensor meant what it emitted, and three shipped
+sensors (``pmd``, ``phpmd``, ``comment``) key an issue by its file, give a line,
+and give no column — so two of their issues on one line are indistinguishable to
+any identity the merge can build from the place alone. Only the tool's
+``message`` tells them apart, and that is deliberately not part of the identity
+(two tools describing one thing disagree about exactly that).
+
+``knip`` used to be a fourth. It now translates knip's ``col`` into the
+``column`` the contract names, and keys by export name, so its issues are told
+apart by the place rule and it is no longer a witness for this one.
+
+Each case below is the shape its sensor really produces; the comment names the
+function that builds it.
+"""
+
+from __future__ import annotations
+
+from habit_hooks.merged_findings import merged
+
+ONE_GUIDE = "guides/the-one.md"
+
+
+def _same_guide(finding: dict) -> str:
+    return ONE_GUIDE
+
+
+def _kept_issues(smell: str, issues: list[dict]) -> list[dict]:
+    finding = {"smell": smell, "details": {}, "issues": issues}
+    return merged([finding], _same_guide)[0]["issues"]
+
+
+def test_two_java_variables_declared_on_one_line_are_two_issues() -> None:
+    """``int a = 1, b = 2;`` is two unused locals at one place.
+    ``pmd_sensor.issue`` keys by file and carries ``beginline``, no column."""
+    issues = [
+        {
+            "key": "src/Order.java",
+            "details": {
+                "file": "src/Order.java",
+                "line": 12,
+                "message": "Avoid unused local variables such as 'a'.",
+                "source": "pmd:UnusedLocalVariable",
+            },
+        },
+        {
+            "key": "src/Order.java",
+            "details": {
+                "file": "src/Order.java",
+                "line": 12,
+                "message": "Avoid unused local variables such as 'b'.",
+                "source": "pmd:UnusedLocalVariable",
+            },
+        },
+    ]
+
+    assert len(_kept_issues("unused-variable", issues)) == 2
+
+
+def test_two_php_variables_assigned_on_one_line_are_two_issues() -> None:
+    """``$a = 1; $b = 2;`` likewise. ``phpmd_sensor.issue`` keys by file and
+    carries ``beginLine``, no column."""
+    issues = [
+        {
+            "key": "src/Order.php",
+            "details": {
+                "file": "src/Order.php",
+                "line": 8,
+                "message": "Avoid unused local variables such as '$a'.",
+                "source": "phpmd:UnusedLocalVariable",
+            },
+        },
+        {
+            "key": "src/Order.php",
+            "details": {
+                "file": "src/Order.php",
+                "line": 8,
+                "message": "Avoid unused local variables such as '$b'.",
+                "source": "phpmd:UnusedLocalVariable",
+            },
+        },
+    ]
+
+    assert len(_kept_issues("unused-variable", issues)) == 2
+
+
+def test_a_block_and_a_line_comment_on_one_line_are_two_issues() -> None:
+    """``foo(/* legacy */ x); // remove me`` is two comments to judge.
+    ``comment.cjs``'s ``issue`` keys by file and carries a line, no column."""
+    issues = [
+        {
+            "key": "src/a.ts",
+            "details": {
+                "file": "src/a.ts",
+                "line": 4,
+                "message": 'block-line comment: "/* legacy */"',
+                "source": "comment:non-essential",
+            },
+        },
+        {
+            "key": "src/a.ts",
+            "details": {
+                "file": "src/a.ts",
+                "line": 4,
+                "message": 'single-line comment: "// remove me"',
+                "source": "comment:non-essential",
+            },
+        },
+    ]
+
+    assert len(_kept_issues("non-essential-comment", issues)) == 2
+
+
+def test_a_later_findings_own_repeated_place_survives_too() -> None:
+    """The rule is not "the first finding is authoritative" — every finding's
+    own list is. A second sensor's two variables on one line both stand, and
+    only what an *earlier* finding already named is dropped."""
+    already_named = {
+        "key": "src/Order.java",
+        "details": {"file": "src/Order.java", "line": 5, "source": "pmd:UnusedLocalVariable"},
+    }
+    on_one_line = [
+        {
+            "key": "src/Order.java",
+            "details": {"file": "src/Order.java", "line": 12, "message": "'a'"},
+        },
+        {
+            "key": "src/Order.java",
+            "details": {"file": "src/Order.java", "line": 12, "message": "'b'"},
+        },
+    ]
+    findings = [
+        {"smell": "unused-variable", "details": {}, "issues": [already_named]},
+        {"smell": "unused-variable", "details": {}, "issues": on_one_line},
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 3

--- a/tests/test_a_smell_is_coached_once.py
+++ b/tests/test_a_smell_is_coached_once.py
@@ -1,0 +1,170 @@
+"""One smell is coached once, however many sensors reported it (#140).
+
+eslint's ``max-lines`` and the generic ``line-count`` sensor both report
+``oversized-file``, so a project running both plugins read the same ~200-word
+guide twice about one file. The mapper prints one block per finding, which is
+why two sensors seeing one smell had to become one finding before anything is
+rendered.
+
+This is the reader's half of that: what reaches stdout, and what the banner
+counts. The merge's own rules are ``test_merging_findings_of_one_smell.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from habit_hooks import mapper
+from plugin_fixture import write_plugin, write_project_config
+
+OVERSIZED_FILE_GUIDE = "Split the file along its seams."
+OVERSIZED_FUNCTION_GUIDE = "Extract the steps this function names."
+LISTING = "{% for issue in issues %}{{ issue.details.file }}\n{% endfor %}"
+
+
+PYTHON_COMPLEXITY_GUIDE = "Split the branches this Python function is holding."
+GENERIC_COMPLEXITY_GUIDE = "Split the branches this function is holding."
+
+
+def _project(tmp_path: Path) -> Path:
+    """A polyglot project, as a consumer running two language plugins has.
+
+    ``gen`` declares no language and coaches every smell; ``py`` coaches the one
+    smell it has a better answer for — which is how a real plugin set is shaped,
+    and what decides whether two findings render alike.
+    """
+    write_plugin(
+        tmp_path,
+        "gen",
+        {
+            "config.toml": "sensors = []",
+            "guides/oversized-file.md": f"{OVERSIZED_FILE_GUIDE}\n\n{LISTING}",
+            "guides/oversized-function.md": f"{OVERSIZED_FUNCTION_GUIDE}\n\n{LISTING}",
+            "guides/high-complexity.md": f"{GENERIC_COMPLEXITY_GUIDE}\n\n{LISTING}",
+        },
+    )
+    write_plugin(
+        tmp_path,
+        "py",
+        {
+            "config.toml": 'language = "python"\nsensors = []',
+            "guides/high-complexity.md": f"{PYTHON_COMPLEXITY_GUIDE}\n\n{LISTING}",
+        },
+    )
+    write_project_config(tmp_path, 'plugins = ["gen", "py"]')
+    return tmp_path
+
+
+def _finding(smell: str, issues: list[dict], **rest: object) -> dict:
+    return {"smell": smell, "details": {}, "issues": issues, **rest}
+
+
+def _at(file: str, **details: object) -> dict:
+    return {"key": file, "details": {"file": file, **details}}
+
+
+def test_two_sensors_reporting_one_smell_print_its_guide_once(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The bug as Frank reported it: the whole guide, twice, about one file.
+
+    Counted against the guide's own text rather than the file path, which a
+    guide is free to list once per issue.
+    """
+    from_eslint = _finding(
+        "oversized-file",
+        [_at("src/big.ts", message="File has too many lines", source="eslint:max-lines")],
+    )
+    from_line_count = _finding(
+        "oversized-file", [_at("src/big.ts", lines=260, source="line-count")]
+    )
+
+    mapper.run([from_eslint, from_line_count], _project(tmp_path))
+
+    assert capsys.readouterr().out.count(OVERSIZED_FILE_GUIDE) == 1
+
+
+def test_one_file_two_sensors_saw_is_one_issue_to_fix(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Both sensors named the same place, so the reader has one thing to do.
+
+    Counted, not merely found: two unmerged findings of one issue each print
+    that same banner twice.
+    """
+    from_eslint = _finding("oversized-file", [_at("src/big.ts", line=None)])
+    from_line_count = _finding("oversized-file", [_at("src/big.ts", lines=260)])
+
+    mapper.run([from_eslint, from_line_count], _project(tmp_path))
+
+    out = capsys.readouterr().out
+    assert out.count("── oversized-file (1 issue) ──") == 1
+    assert "(2 issues)" not in out
+
+
+def test_every_oversized_function_in_one_file_is_still_its_own_issue(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The eslint sensor keys every message by its file, so a line-level smell
+    arrives as many issues sharing one key. Collapsing those would tell a reader
+    with seven long functions that they have one."""
+    issues = [_at("src/big.ts", line=line) for line in (3, 40, 80, 120, 160, 200, 240)]
+
+    mapper.run([_finding("oversized-function", issues)], _project(tmp_path))
+
+    assert "── oversized-function (7 issues) ──" in capsys.readouterr().out
+
+
+def test_different_smells_keep_their_own_blocks_in_arrival_order(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Merging is per smell; two smells are still two blocks, still in the order
+    the findings arrived."""
+    findings = [
+        _finding("oversized-function", [_at("src/a.ts", line=3)]),
+        _finding("oversized-file", [_at("src/b.ts")]),
+    ]
+
+    mapper.run(findings, _project(tmp_path))
+
+    out = capsys.readouterr().out
+    assert out.index("oversized-function") < out.index("oversized-file")
+
+
+def test_one_smell_two_plugins_coach_differently_stays_two_blocks(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`high-complexity` has a Python guide and a generic one. Merging on the
+    smell alone would coach whichever file arrived second in the other one's
+    language — the `.ts` file explained in Python, or the `.py` file quietly
+    losing its Python guidance."""
+    findings = [
+        _finding("high-complexity", [_at("src/a.py", line=12)], language="python"),
+        _finding("high-complexity", [_at("src/b.ts", line=40)], language="typescript"),
+    ]
+
+    mapper.run(findings, _project(tmp_path))
+
+    out = capsys.readouterr().out
+    assert out.count("── high-complexity (1 issue) ──") == 2
+    assert PYTHON_COMPLEXITY_GUIDE in out
+    assert GENERIC_COMPLEXITY_GUIDE in out
+
+
+def test_each_file_is_listed_under_the_guide_that_coaches_it(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The half a block count alone would not catch: the right file under the
+    right guide, rather than both files under one of them."""
+    findings = [
+        _finding("high-complexity", [_at("src/a.py", line=12)], language="python"),
+        _finding("high-complexity", [_at("src/b.ts", line=40)], language="typescript"),
+    ]
+
+    mapper.run(findings, _project(tmp_path))
+
+    python_block, generic_block = capsys.readouterr().out.split(GENERIC_COMPLEXITY_GUIDE)
+    assert "src/a.py" in python_block
+    assert "src/b.ts" in generic_block
+    assert "src/b.ts" not in python_block

--- a/tests/test_catalogue_coverage.py
+++ b/tests/test_catalogue_coverage.py
@@ -5,7 +5,7 @@ with no ``guides/<smell>.md`` falls through to the one-size ``uncoached.md``,
 silently degrading the product. This test turns that gap into a build failure so
 it cannot reopen (#101).
 
-It routes each smell through the real ``rendering._resolve_guide`` against the
+It routes each smell through the real ``rendering.resolve_guide`` against the
 full installed plugin set, exactly as a live run would, and asserts the resolved
 guide is not the uncoached fallback.
 """
@@ -47,7 +47,7 @@ class Routing:
 
     def guide_for(self, smell: str, language: str | None) -> str:
         finding = {"smell": smell, "language": language, "details": {}, "issues": []}
-        return rendering._resolve_guide(finding, self.config, self.resolver).name
+        return rendering.resolve_guide(finding, self.config, self.resolver).name
 
 
 @pytest.mark.parametrize("smell", sorted(DEFAULT_SEVERITY))

--- a/tests/test_git_batching.py
+++ b/tests/test_git_batching.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from git_repo import commit_file, git, repository_with_committed_file
-from habit_hooks import git_history
+from habit_hooks import git_command
 from habit_hooks.changed_files import changed_against_base
 
 
@@ -31,7 +31,7 @@ def _recorded_diffs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
             calls.append(tuple(args))
         return spawn(args, **spawn_options)
 
-    monkeypatch.setattr(git_history.subprocess, "run", recording_run)
+    monkeypatch.setattr(git_command.subprocess, "run", recording_run)
     return calls
 
 

--- a/tests/test_git_command.py
+++ b/tests/test_git_command.py
@@ -1,0 +1,79 @@
+"""Unit tests for the one place a git question is spawned.
+
+Everything above this module — a scope, a lapsing snooze, a whole-project scan —
+degrades on an empty answer and falls back to something safe. That only works if
+an answer is empty *whenever git failed*, so this is where that is pinned: git
+is perfectly capable of printing a plausible-looking line to stdout and then
+exiting non-zero, and a caller reading the line would take a failure for a fact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git_repo import git, repository, repository_with_committed_file
+from habit_hooks import git_command, git_history
+
+# A repository with no commits yet has a HEAD pointing at an unborn branch.
+# `rev-parse --abbrev-ref HEAD` cannot resolve it: it exits 128 *and* prints the
+# literal string "HEAD" on stdout — a failure that looks exactly like an answer.
+_UNRESOLVABLE_HEAD = ("rev-parse", "--abbrev-ref", "HEAD")
+
+
+def test_a_failing_git_answers_nothing_even_when_it_printed_something(
+    tmp_path: Path,
+) -> None:
+    """The exit code is what decides, never whether stdout came back non-empty.
+
+    Trusting the output alone would publish "HEAD" as this repository's branch
+    name. Every degrade in this tool keys off an empty answer, so a failure that
+    smuggles a line through arrives as a fact nothing downstream can question.
+    """
+    repository(tmp_path)
+    printed = git_command.git(tmp_path, *_UNRESOLVABLE_HEAD)
+
+    assert printed is not None
+    assert printed.returncode != 0
+    assert printed.stdout.strip() == "HEAD"  # the situation under test
+    assert git_command.git_output(tmp_path, *_UNRESOLVABLE_HEAD) == ""
+
+
+def test_a_repository_with_no_commits_is_on_no_branch(tmp_path: Path) -> None:
+    """What the guard above buys its caller: an unborn branch is no branch.
+
+    ``head_branch`` documents empty as "HEAD is not on a branch", and a project
+    whose first commit is still to come is exactly that. Answering "HEAD" would
+    make it a branch name like any other, and one a project could match its
+    ``[scope] mainBranch`` against by writing the word.
+    """
+    repository(tmp_path)
+    assert git_history.head_branch(tmp_path) == ""
+
+
+def test_a_successful_git_answers_with_what_it_printed(tmp_path: Path) -> None:
+    """The other half: exit 0 means the output is the answer, stripped."""
+    repository_with_committed_file(tmp_path)
+    assert git_history.head_branch(tmp_path) == "main"
+
+
+def test_a_detached_head_keeps_gits_own_word_for_it(tmp_path: Path) -> None:
+    """"HEAD" is a real answer when git exits 0 with it, so the guard cannot be
+    "reject the word HEAD" — only the exit code tells the two cases apart."""
+    repository_with_committed_file(tmp_path)
+    git(tmp_path, "checkout", "-q", "--detach")
+    assert git_history.head_branch(tmp_path) == "HEAD"
+
+
+def test_git_that_cannot_be_run_at_all_answers_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No git on the machine is the third silence, and it must not raise."""
+
+    def no_git(*_args: object, **_options: object) -> object:
+        raise OSError("git: command not found")
+
+    monkeypatch.setattr(git_command.subprocess, "run", no_git)
+    assert git_command.git(tmp_path, "status") is None
+    assert git_command.git_output(tmp_path, "status") == ""

--- a/tests/test_git_history.py
+++ b/tests/test_git_history.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from git_repo import commit_file, git, repository_with_committed_file
-from habit_hooks import git_history
+from habit_hooks import git_command, git_history
 
 
 def test_a_directory_no_repository_holds_is_not_placed(tmp_path: Path) -> None:
@@ -36,7 +36,7 @@ def test_git_that_cannot_be_run_places_nothing(
     def no_git(*_args: object, **_options: object) -> object:
         raise OSError("git: command not found")
 
-    monkeypatch.setattr(git_history.subprocess, "run", no_git)
+    monkeypatch.setattr(git_command.subprocess, "run", no_git)
     assert git_history.places_directory(tmp_path) is False
 
 
@@ -114,21 +114,6 @@ def test_a_non_ascii_path_comes_back_unquoted(tmp_path: Path) -> None:
     commit_file(accented, "VALUES = [2]\n")
     accented.write_text("VALUES = [2, 3]\n", encoding="utf-8")
     assert git_history.changed_paths(tmp_path, []) == ["café.py"]
-
-
-def test_an_untracked_file_is_named(tmp_path: Path) -> None:
-    """The file `git diff` never mentions, and a scoped run must still measure."""
-    repository_with_committed_file(tmp_path)
-    (tmp_path / "fresh.py").write_text("VALUES = [1]\n", encoding="utf-8")
-    assert git_history.untracked_paths(tmp_path) == ["fresh.py"]
-
-
-def test_an_ignored_file_is_not_named_untracked(tmp_path: Path) -> None:
-    """`--exclude-standard` keeps a build artifact out of the work in progress."""
-    repository_with_committed_file(tmp_path)
-    (tmp_path / ".gitignore").write_text("build.py\n", encoding="utf-8")
-    (tmp_path / "build.py").write_text("VALUES = [9]\n", encoding="utf-8")
-    assert "build.py" not in git_history.untracked_paths(tmp_path)
 
 
 def test_uncommitted_changes_unite_the_three_kinds_of_work(tmp_path: Path) -> None:

--- a/tests/test_git_listing.py
+++ b/tests/test_git_listing.py
@@ -1,0 +1,29 @@
+"""Unit tests for what git says the working tree holds right now.
+
+The counterpart to ``test_git_history.py``: these pin ``git ls-files``' answers
+— which files a project keeps, and which of them the ignore rules take back —
+where those pin what git remembers between two revisions. What a whole-project
+scan then *does* with these answers is the ``test_a_scan_*`` modules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from git_repo import repository_with_committed_file
+from habit_hooks import git_listing
+
+
+def test_an_untracked_file_is_named(tmp_path: Path) -> None:
+    """The file `git diff` never mentions, and a scoped run must still measure."""
+    repository_with_committed_file(tmp_path)
+    (tmp_path / "fresh.py").write_text("VALUES = [1]\n", encoding="utf-8")
+    assert git_listing.untracked_paths(tmp_path) == ["fresh.py"]
+
+
+def test_an_ignored_file_is_not_named_untracked(tmp_path: Path) -> None:
+    """`--exclude-standard` keeps a build artifact out of the work in progress."""
+    repository_with_committed_file(tmp_path)
+    (tmp_path / ".gitignore").write_text("build.py\n", encoding="utf-8")
+    (tmp_path / "build.py").write_text("VALUES = [9]\n", encoding="utf-8")
+    assert "build.py" not in git_listing.untracked_paths(tmp_path)

--- a/tests/test_how_much_a_failure_says.py
+++ b/tests/test_how_much_a_failure_says.py
@@ -1,0 +1,176 @@
+"""How much of a failing part's own words the notice carries back.
+
+``diagnosis.py``'s question, and a separate one from which failure is being
+described (``test_part_output.py``). habit-hooks writes into a coding agent's
+context, so a tool with a great deal to say is bounded two ways — by lines, and
+within a line — while one with little to say is quoted whole.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sensor_notice import script_notice
+
+import pytest
+
+from habit_hooks.sensors import diagnosis
+from habit_hooks.sensors.diagnosis import (
+    DIAGNOSIS_LINE_LIMIT,
+    DIAGNOSIS_LINE_LENGTH_LIMIT,
+    keep_both_ends,
+)
+
+
+def test_a_sensor_at_the_truncation_boundary_is_still_quoted_whole(
+    tmp_path: Path,
+) -> None:
+    """Truncating only pays for itself once the excerpt it produces — head, an
+    elision line, and tail — is actually shorter than the diagnosis it would
+    replace. At 21 lines the excerpt would also come to 21 lines, so nothing is
+    dropped, and nothing is lost for free."""
+    notice = script_notice(
+        tmp_path,
+        "import sys\n"
+        "for i in range(1, 22):\n"
+        "    print(f'line {i}', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+    )
+    lines = notice.splitlines()
+
+    assert "line 1" in lines
+    assert "line 21" in lines
+    assert "omitted" not in notice
+
+
+def test_a_sensor_one_line_past_the_boundary_finally_elides(tmp_path: Path) -> None:
+    """One line more and the excerpt is finally shorter than the diagnosis it
+    replaces, so it elides — head, tail, and the middle it stands in for."""
+    notice = script_notice(
+        tmp_path,
+        "import sys\n"
+        "for i in range(1, 23):\n"
+        "    print(f'line {i}', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+    )
+    lines = notice.splitlines()
+
+    assert "line 1" in lines
+    assert "line 11" not in lines
+    assert "line 22" in lines
+    assert "... 2 lines omitted ..." in lines
+
+
+def test_a_sensor_whose_last_line_carries_the_diagnosis_still_quotes_it(
+    tmp_path: Path,
+) -> None:
+    """A Python traceback names its exception on its *last* line, not its first.
+
+    A chatty tool that dies with a traceback — the shape every Python-helper
+    sensor's own crash takes, deptry included — buries its one useful line at
+    the bottom of output that easily runs past the quoted budget. Quoting only
+    the head, as this once did, guarantees that line is exactly the one
+    dropped; the tail has to survive too.
+    """
+    notice = script_notice(
+        tmp_path,
+        "import sys\n"
+        "for i in range(1, 25):\n"
+        '    print(f"noise {i}", file=sys.stderr)\n'
+        'raise RuntimeError("boom: the real reason")\n',
+    )
+
+    assert "boom: the real reason" in notice
+
+
+def test_a_sensor_that_says_it_all_on_one_line_is_still_cut_down(
+    tmp_path: Path,
+) -> None:
+    """A budget counted in lines bounds a chatty tool, not a terse one.
+
+    ``eslint -f json`` is a single line however many megabytes it holds, so a
+    tool that dies printing one clears a twenty-line limit without shedding a
+    byte — and the whole of it lands in a notice habit-hooks writes into a
+    coding agent's context, which is the cost this budget exists to bound.
+    """
+    notice = script_notice(
+        tmp_path,
+        "import sys\n"
+        "print('S' * 2_000_000 + 'THE REAL COMPLAINT', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+    )
+
+    assert len(notice) < 10_000, f"notice carried {len(notice)} characters"
+    assert "THE REAL COMPLAINT" in notice, "the end of the line is the punchline"
+    assert "omitted" in notice, "and it says the middle was dropped"
+
+
+def test_a_line_exactly_at_its_budget_is_quoted_whole(tmp_path: Path) -> None:
+    """Cutting is only worth doing once there is something to cut."""
+    notice = script_notice(
+        tmp_path,
+        "import sys\n"
+        f"print('S' * {DIAGNOSIS_LINE_LENGTH_LIMIT}, file=sys.stderr)\n"
+        "sys.exit(1)\n",
+    )
+
+    assert "S" * DIAGNOSIS_LINE_LENGTH_LIMIT in notice
+    assert "omitted" not in notice
+
+
+def test_cutting_a_line_never_makes_it_longer() -> None:
+    """A line just past the budget costs more to elide than it saves.
+
+    The elision has to say how much it hides, and that sentence is longer than
+    the handful of characters an only-just-oversized line has to give up — so
+    quoting it whole is both shorter and more use. The line budget already
+    works this way; this is the same economy one scale down, and without it
+    every line from one past the budget to about thirty past came back *longer*
+    than it went in, announcing ``1 characters omitted``.
+
+    Asked of the budget rather than of a hard-coded boundary: where cutting
+    starts to pay follows from the elision's own length, so a reworded elision
+    must not become a silently wrong boundary.
+    """
+    over = range(DIAGNOSIS_LINE_LENGTH_LIMIT, DIAGNOSIS_LINE_LENGTH_LIMIT + 100)
+
+    for length in over:
+        quoted = keep_both_ends("x" * length)
+        assert len(quoted) <= length, f"{length} characters came back as {len(quoted)}"
+
+
+def test_a_line_far_past_its_budget_keeps_both_of_its_ends() -> None:
+    """Far enough past it, the middle is worth dropping — and both ends live.
+
+    Which end carries the complaint is no more predictable inside a line than
+    across a stack trace: a tool that dumps what it was reading and then says
+    why puts the reason last.
+    """
+    quoted = keep_both_ends("HEAD" + "x" * 5_000 + "TAIL")
+
+    assert quoted.startswith("HEAD")
+    assert quoted.endswith("TAIL")
+    assert "characters omitted" in quoted
+    assert len(quoted) < 1_100
+
+
+def test_only_the_lines_that_survive_are_cut_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The work is bounded by the budget, not by how much the tool said.
+
+    Cutting every line before choosing which twenty to keep costs a second copy
+    of the whole input — on the megabytes this module exists to bound, that is
+    tens of megabytes allocated to produce twenty thousand characters. Choosing
+    first makes the cost the same for a stderr of ten lines and one of ten
+    million, which is measured here as how many lines are ever looked at.
+    """
+    cut = diagnosis._both_ends_of
+    seen = []
+    monkeypatch.setattr(
+        diagnosis, "_both_ends_of", lambda line: seen.append(line) or cut(line)
+    )
+
+    diagnosis.keep_both_ends("\n".join("x" * 2_000 for _ in range(10_000)))
+
+    assert len(seen) <= DIAGNOSIS_LINE_LIMIT + 1, f"cut {len(seen)} lines down"

--- a/tests/test_merging_findings_of_one_smell.py
+++ b/tests/test_merging_findings_of_one_smell.py
@@ -1,0 +1,164 @@
+"""Which findings become one finding, and what the merged one says (#140).
+
+Which of their *issues* survive is ``test_which_issues_survive_a_merge.py``'s
+subject; what a reader sees is ``test_a_smell_is_coached_once.py``'s.
+
+``merged`` is handed the question "which guide would this finding render" rather
+than answering it, so these cases answer it themselves — the mapper answers it
+with ``rendering.resolve_guide``.
+"""
+
+from __future__ import annotations
+
+from habit_hooks.merged_findings import merged
+
+ONE_GUIDE = "guides/the-one.md"
+
+
+def _same_guide(finding: dict) -> str:
+    return ONE_GUIDE
+
+
+def _guide_of_its_language(finding: dict) -> str:
+    """What the real resolution does for a smell two plugins both coach: the
+    language picks the plugin, and the plugin picks the file."""
+    return f"{finding.get('language')}/{finding['smell']}.md"
+
+
+def _finding(smell: str, issues: list[dict], **rest: object) -> dict:
+    return {"smell": smell, "details": {}, "issues": issues, **rest}
+
+
+def _at(file: str, **details: object) -> dict:
+    return {"key": file, "details": {"file": file, **details}}
+
+
+def test_no_findings_merge_into_no_findings() -> None:
+    assert merged([], _same_guide) == []
+
+
+def test_one_finding_comes_back_as_it_was() -> None:
+    finding = _finding("oversized-file", [_at("src/a.py")], language="python")
+
+    assert merged([finding], _same_guide) == [finding]
+
+
+def test_merging_leaves_the_findings_it_was_handed_alone() -> None:
+    """``merged`` answers a question about the findings it is given; a merge
+    that edited them would make a sensor's own output depend on having been
+    rendered."""
+    finding = _finding("oversized-file", [_at("src/a.py")])
+
+    merged([finding, _finding("oversized-file", [_at("src/b.py")])], _same_guide)
+
+    assert finding["issues"] == [_at("src/a.py")]
+
+
+def test_a_smell_arriving_three_times_is_one_finding() -> None:
+    """jscpd emits a finding per clone, so a run of any size arrives this way."""
+    findings = [_finding("duplicated-code", [_at(f"src/{n}.py")]) for n in "abc"]
+
+    assert len(merged(findings, _same_guide)) == 1
+
+
+def test_issues_keep_the_order_they_arrived_in() -> None:
+    findings = [
+        _finding("oversized-file", [_at("src/a.py"), _at("src/b.py")]),
+        _finding("oversized-file", [_at("src/c.py")]),
+    ]
+
+    issues = merged(findings, _same_guide)[0]["issues"]
+
+    assert [issue["key"] for issue in issues] == ["src/a.py", "src/b.py", "src/c.py"]
+
+
+def test_one_smell_coached_by_two_plugins_stays_two_findings() -> None:
+    """A polyglot repo's `high-complexity` routes to the python plugin's guide
+    for a `.py` file and to generic's for a `.ts` one. Merged on the smell alone,
+    whichever arrived first would coach both — a TypeScript file explained in
+    Python."""
+    findings = [
+        _finding("high-complexity", [_at("src/a.py", line=12)], language="python"),
+        _finding("high-complexity", [_at("src/b.ts", line=40)], language="typescript"),
+    ]
+
+    assert len(merged(findings, _guide_of_its_language)) == 2
+
+
+def test_two_smells_sharing_one_guide_keep_their_own_banners() -> None:
+    """A ``[smells.<name>] guide`` override can point two smells at one file, and
+    the banner names the smell — so the guide alone cannot be the key."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py")]),
+        _finding("high-complexity", [_at("src/a.py")]),
+    ]
+
+    assert [f["smell"] for f in merged(findings, _same_guide)] == [
+        "oversized-file",
+        "high-complexity",
+    ]
+
+
+def test_a_fact_only_one_finding_stated_survives() -> None:
+    """``line-count`` states the threshold it enforced and eslint does not, so a
+    guide rendering ``details.maxAllowed`` needs the merge to keep it."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py")]),
+        {
+            "smell": "oversized-file",
+            "details": {"maxAllowed": 200},
+            "issues": [_at("src/b.py")],
+        },
+    ]
+
+    assert merged(findings, _same_guide)[0]["details"] == {"maxAllowed": 200}
+
+
+def test_a_fact_two_findings_disagree_about_is_dropped() -> None:
+    """jscpd's ``lines`` describes one clone pair. Three pairs in one finding
+    have no single answer, and publishing the first pair's as the whole
+    finding's would teach the reader a wrong number — where a missing key
+    renders as nothing at all."""
+    findings = [
+        {"smell": "duplicated-code", "details": {"lines": 21}, "issues": []},
+        {"smell": "duplicated-code", "details": {"lines": 40}, "issues": []},
+    ]
+
+    assert merged(findings, _same_guide)[0]["details"] == {}
+
+
+def test_a_language_the_first_finding_did_not_carry_is_taken_from_the_next() -> None:
+    """The runner stamps ``language`` from the producing plugin, and ``generic``
+    declares none — so the languageless finding is often the one that arrives
+    first."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.ts")]),
+        _finding("oversized-file", [_at("src/b.ts")], language="typescript"),
+    ]
+
+    assert merged(findings, _same_guide)[0]["language"] == "typescript"
+
+
+def test_the_first_finding_to_name_a_top_level_value_keeps_it() -> None:
+    """First non-null, not last — the merged ``language`` is re-read when the
+    guide renders, so the answer has to be one of the group's own."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py")], language="python"),
+        _finding("oversized-file", [_at("src/b.ts")], language="typescript"),
+    ]
+
+    assert merged(findings, _same_guide)[0]["language"] == "python"
+
+
+def test_a_fact_restated_after_a_contradiction_stays_dropped() -> None:
+    """jscpd states ``lines`` per clone pair, so three pairs of 21, 40 and 21
+    lines is ordinary. Once two findings have disagreed the key has no answer,
+    and a third agreeing with the first must not put the first one back — that
+    is the wrong number this exists to keep out, arriving one finding later."""
+    findings = [
+        {"smell": "duplicated-code", "details": {"lines": 21}, "issues": []},
+        {"smell": "duplicated-code", "details": {"lines": 40}, "issues": []},
+        {"smell": "duplicated-code", "details": {"lines": 21}, "issues": []},
+    ]
+
+    assert merged(findings, _same_guide)[0]["details"] == {}

--- a/tests/test_part_output.py
+++ b/tests/test_part_output.py
@@ -1,8 +1,9 @@
 """What a broken sensor's output becomes: the notice the run reports.
 
 Running a part is ``test_sensor_deadline.py`` and ``test_sensor_environment.py``;
-this is the reading back — how a failure is described once the command has
-exited. A command nobody installed is the one failure the tool has no words of
+this is the reading back — which failure is being described, once the command
+has exited. How much of the tool's own words come with it is
+``test_how_much_a_failure_says.py``. A command nobody installed is the one failure the tool has no words of
 its own for, because it never ran, so habit-hooks supplies them (#114).
 """
 
@@ -13,38 +14,9 @@ from pathlib import Path
 import pytest
 from platform_probe import A_SHELL_TO_RUN_IT_WITH, off_windows
 
-from habit_hooks.scope import Scope
-from habit_hooks.sensors.execution import Execution
+from sensor_notice import only_notice, script_notice, sensor_notice
+
 from habit_hooks.sensors.model import Part
-
-
-def _sensor_notice(tmp_path: Path, command: str) -> str:
-    """The one notice a sensor running ``command`` leaves on its failed run."""
-    return _only_notice(Part(name="probe", command=command, directory=tmp_path), tmp_path)
-
-
-def _script_notice(tmp_path: Path, script: str) -> str:
-    """The one notice a sensor running python ``script`` leaves on its failed run.
-
-    No shell is needed for what these tests prove — how a broken part's own
-    output is quoted back — so this spells an ``argv`` part, unlike the real
-    shell's own ``command not found`` diagnosis ``_sensor_notice`` above needs.
-    """
-    (tmp_path / "probe.py").write_text(script, encoding="utf-8")
-    part = Part(name="probe", directory=tmp_path, argv=["${python}", "${dir}/probe.py"])
-    return _only_notice(part, tmp_path)
-
-
-def _only_notice(part: Part, project_dir: Path) -> str:
-    """The one notice ``part`` leaves on the failed run it produces."""
-    execution = Execution(project_dir=project_dir, scope=Scope(files=["src/a.py"]))
-
-    run = execution.run_sensors([part])
-
-    assert run.findings == []
-    assert run.failed
-    assert len(run.notices) == 1
-    return run.notices[0]
 
 
 @A_SHELL_TO_RUN_IT_WITH
@@ -64,7 +36,7 @@ def test_a_sensor_whose_tool_is_not_installed_names_the_tool(
     ``test_an_argv_sensor_names_its_missing_tool_in_the_very_same_words`` below.
     """
     off_windows(monkeypatch)
-    notice = _sensor_notice(tmp_path, "no-such-tool-here --json ${files}")
+    notice = sensor_notice(tmp_path, "no-such-tool-here --json ${files}")
 
     assert notice == (
         "habit-sensors: sensor 'probe' needs the 'no-such-tool-here' command, "
@@ -85,7 +57,7 @@ def test_a_tool_missing_from_inside_a_pipeline_is_named_too(
     off_windows(monkeypatch)
     pipeline = "set -o pipefail\nno-such-tool-here | jq ."
 
-    assert "needs the 'no-such-tool-here' command" in _sensor_notice(tmp_path, pipeline)
+    assert "needs the 'no-such-tool-here' command" in sensor_notice(tmp_path, pipeline)
 
 
 def test_a_sensor_that_broke_some_other_way_still_quotes_itself_back(
@@ -94,7 +66,7 @@ def test_a_sensor_that_broke_some_other_way_still_quotes_itself_back(
     """Only a command that was never found is answered in our own words. Every
     other failure is the tool diagnosing itself, and that is the one thing a
     reader can act on, so it is still carried into the notice verbatim."""
-    notice = _script_notice(
+    notice = script_notice(
         tmp_path,
         "import sys\n"
         "print('cannot reach registry', file=sys.stderr)\n"
@@ -103,67 +75,6 @@ def test_a_sensor_that_broke_some_other_way_still_quotes_itself_back(
 
     assert notice.startswith("habit-sensors: sensor 'probe' failed:")
     assert "cannot reach registry" in notice
-
-
-def test_a_sensor_at_the_truncation_boundary_is_still_quoted_whole(
-    tmp_path: Path,
-) -> None:
-    """Truncating only pays for itself once the excerpt it produces — head, an
-    elision line, and tail — is actually shorter than the diagnosis it would
-    replace. At 21 lines the excerpt would also come to 21 lines, so nothing is
-    dropped, and nothing is lost for free."""
-    notice = _script_notice(
-        tmp_path,
-        "import sys\n"
-        "for i in range(1, 22):\n"
-        "    print(f'line {i}', file=sys.stderr)\n"
-        "sys.exit(1)\n",
-    )
-    lines = notice.splitlines()
-
-    assert "line 1" in lines
-    assert "line 21" in lines
-    assert "omitted" not in notice
-
-
-def test_a_sensor_one_line_past_the_boundary_finally_elides(tmp_path: Path) -> None:
-    """One line more and the excerpt is finally shorter than the diagnosis it
-    replaces, so it elides — head, tail, and the middle it stands in for."""
-    notice = _script_notice(
-        tmp_path,
-        "import sys\n"
-        "for i in range(1, 23):\n"
-        "    print(f'line {i}', file=sys.stderr)\n"
-        "sys.exit(1)\n",
-    )
-    lines = notice.splitlines()
-
-    assert "line 1" in lines
-    assert "line 11" not in lines
-    assert "line 22" in lines
-    assert "... 2 lines omitted ..." in lines
-
-
-def test_a_sensor_whose_last_line_carries_the_diagnosis_still_quotes_it(
-    tmp_path: Path,
-) -> None:
-    """A Python traceback names its exception on its *last* line, not its first.
-
-    A chatty tool that dies with a traceback — the shape every Python-helper
-    sensor's own crash takes, deptry included — buries its one useful line at
-    the bottom of output that easily runs past the quoted budget. Quoting only
-    the head, as this once did, guarantees that line is exactly the one
-    dropped; the tail has to survive too.
-    """
-    notice = _script_notice(
-        tmp_path,
-        "import sys\n"
-        "for i in range(1, 25):\n"
-        '    print(f"noise {i}", file=sys.stderr)\n'
-        'raise RuntimeError("boom: the real reason")\n',
-    )
-
-    assert "boom: the real reason" in notice
 
 
 def test_an_argv_sensor_names_its_missing_tool_in_the_very_same_words(
@@ -178,7 +89,7 @@ def test_an_argv_sensor_names_its_missing_tool_in_the_very_same_words(
         name="probe", directory=tmp_path, argv=["no-such-tool-here", "--json"]
     )
 
-    assert _only_notice(part, tmp_path) == (
+    assert only_notice(part, tmp_path) == (
         "habit-sensors: sensor 'probe' needs the 'no-such-tool-here' command, "
         "which is not installed — install it, or disable the sensor with "
         "[sensors.probe] disabled = true"
@@ -194,7 +105,8 @@ def test_a_spawn_refused_for_another_reason_is_not_called_a_missing_tool(
     installed and send the reader off to install it again."""
     part = Part(name="probe", directory=tmp_path, argv=["printf", "[]"])
 
-    notice = _only_notice(part, tmp_path / "deleted")
+    notice = only_notice(part, tmp_path / "deleted")
 
     assert "needs the" not in notice
     assert notice.startswith("habit-sensors: sensor 'probe' could not run: printf '[]'")
+

--- a/tests/test_scope_notices.py
+++ b/tests/test_scope_notices.py
@@ -10,9 +10,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from git_repo import repository, stop_the_upward_walk_at, written
 from habit_hooks.config import Config
 from scope_probe import scope as _scope
 from scope_probe import source_file
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _only_the_repository_the_case_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop_the_upward_walk_at(tmp_path, monkeypatch)
 
 
 def test_a_named_file_outside_files_is_not_scanned(tmp_path: Path) -> None:
@@ -60,4 +70,24 @@ def test_no_files_at_all_scans_nothing_and_says_why(tmp_path: Path) -> None:
     assert scoped.notices == [
         "habit-sensors: no [files] are configured — name what to scan in "
         ".habit-hooks/config.toml; nothing scanned"
+    ]
+
+
+def test_a_files_that_matched_nothing_says_so(tmp_path: Path) -> None:
+    """The case that was silent, and the reason it mattered.
+
+    A project whose ``.gitignore`` covers its own source tree keeps no files git
+    will name, so ``[files]`` — set, and correct — matches nothing. That scanned
+    zero files and rendered ✅: a run that *measured* nothing, told apart from a
+    run that *found* nothing only by this line (#88).
+    """
+    project = repository(tmp_path / "project", ignoring="src/\n")
+    written(project / "src" / "a.py")
+    scoped = _scope(["--all"], project, Config(files=["**/*.py"]))
+
+    assert scoped.files == []
+    assert scoped.notices == [
+        "habit-sensors: nothing matched [files] — check it in "
+        ".habit-hooks/config.toml, and whether git ignores the paths you "
+        "expected; nothing scanned"
     ]

--- a/tests/test_the_shipped_knip_config_ignores_what_we_asked_for.py
+++ b/tests/test_the_shipped_knip_config_ignores_what_we_asked_for.py
@@ -1,0 +1,89 @@
+"""The shipped knip config overlooks habit-hooks' footprint — all of it, and nothing else.
+
+A project installs the packages habit-hooks tells it to, imports none of them
+because habit-hooks is what uses them, and knip then reports every one as an
+unused dependency (#143). The answer is ``ignoreDependencies`` in the
+typescript plugin's shipped ``knip.json``, and this is what keeps that list
+honest in both directions.
+
+**Complete**, or the bug comes back one package at a time: a plugin that grows
+a ``node-module`` detector, or a shipped eslint config that grows a plugin,
+adds a package to every consumer's manifest, and nobody adding one has any
+reason to open ``knip.json``.
+
+**Minimal**, or the smell quietly stops working: a name in that list is a name
+no project is ever told about again, so one that is not our footprint suppresses
+a finding the project needed. That drift is invisible to the plugin's own
+behaviour suite, which only ever sees the packages its fixture plants.
+
+It lives here rather than in the typescript plugin's suite for the reason
+``test_a_plugin_declares_the_tools_it_names.py`` does: the answer is derived
+from *every* plugin's declarations, not one plugin's. jscpd is the case that
+makes that concrete — it is the **generic** plugin's detector, but knip is what
+reads ``package.json`` and knip belongs to the typescript plugin, so the only
+config that can name jscpd is a config in a different plugin from the one that
+asked for it. A gate inside either plugin's suite could only ever see half of
+that.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from habit_hooks.config_schema import read_toml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TYPESCRIPT = REPO_ROOT / "plugins" / "typescript" / "src" / "habit_hooks_typescript"
+SHIPPED_KNIP_CONFIG = TYPESCRIPT / "knip.json"
+SHIPPED_ESLINT_CONFIG = TYPESCRIPT / "eslint.config.mjs"
+
+# How a plugin spells "this one lands in the project's package.json".
+NPM_INSTALL = "npm install"
+
+# A `node-module` detector is always an npm package; a `command` detector may
+# be one too (jscpd is spawned by name and still installed with npm), and node
+# itself is neither. So the question is the install line, with the kind as a
+# belt-and-braces second answer — a node-module that forgot its install line
+# would otherwise slip past.
+NODE_MODULE = "node-module"
+
+# What the shipped eslint config asks the *project* to have installed, spelled
+# as `required("<package>")` so it can say so itself when the package is absent
+# (`eslint.config.mjs`, MISSING_TYPESCRIPT_ESLINT).
+REQUIRED_PACKAGE = re.compile(r'required\(\s*"([^"]+)"\s*\)')
+
+# knip leaves itself out of its own answer, so naming it would be a line that
+# can never do anything — and a list carrying dead entries is a list nobody
+# trusts to be minimal. (Confirmed against knip 5.88.1, which also excludes
+# `typescript`; that one is nobody's detector, so it never reaches this set.)
+KNIP_EXCLUDES_ITSELF = "knip"
+
+
+def _packages_a_plugin_asks_for(config: Path) -> set[str]:
+    return {
+        detector["name"]
+        for detector in read_toml(config).get("detectors", [])
+        if detector.get("kind") == NODE_MODULE
+        or detector.get("install", "").startswith(NPM_INSTALL)
+    }
+
+
+def _our_footprint_in_a_project() -> set[str]:
+    """Every package habit-hooks asks a project to install."""
+    configs = sorted(REPO_ROOT.glob("plugins/*/src/habit_hooks_*/config.toml"))
+    assert configs, "no shipped plugin configs found — the glob has gone stale"
+
+    declared = set().union(*(_packages_a_plugin_asks_for(one) for one in configs))
+    required = set(
+        REQUIRED_PACKAGE.findall(SHIPPED_ESLINT_CONFIG.read_text(encoding="utf-8"))
+    )
+    assert required, "the shipped eslint config named nothing — the pattern has gone stale"
+    return (declared | required) - {KNIP_EXCLUDES_ITSELF}
+
+
+def test_the_shipped_config_overlooks_our_footprint_and_only_our_footprint() -> None:
+    shipped = json.loads(SHIPPED_KNIP_CONFIG.read_text(encoding="utf-8"))
+
+    assert sorted(shipped["ignoreDependencies"]) == sorted(_our_footprint_in_a_project())

--- a/tests/test_what_counts_as_a_submodule.py
+++ b/tests/test_what_counts_as_a_submodule.py
@@ -1,0 +1,93 @@
+"""Which entries in git's index are submodule mount points, and which only look
+like one from the filesystem.
+
+A submodule is a **gitlink** — another repository checked out inside this one —
+and git stores it with mode ``160000``. Nothing else has that mode, so the
+question has an exact answer and ``.gitmodules`` never has to be read.
+
+``Path.is_dir()`` cannot answer it. It follows symlinks, so a tracked symlink to
+a directory (mode ``120000``) is indistinguishable from a gitlink — and a
+symlinked ``node_modules`` is pnpm's ordinary layout, which makes that the
+common case rather than a corner. These are the cases that hold the mode
+question in place.
+
+What a scan then *says* about a submodule it recognised is
+``test_a_scan_names_the_submodules_it_skipped.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from git_repo import committed, repository, stop_the_upward_walk_at, tracked_symlink, written
+from habit_hooks.config import Config
+from platform_probe import A_MACHINE_THAT_CAN_MAKE_A_SYMLINK
+from scope_probe import scope as _scope
+
+# Discovery is opt-in since #97: a case must name its source before any mode
+# enumerates anything.
+_PY_SOURCE = ["**/*.py"]
+
+
+@pytest.fixture(autouse=True)
+def _only_the_repository_the_case_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop_the_upward_walk_at(tmp_path, monkeypatch)
+
+
+def test_an_ordinary_directory_is_never_called_a_submodule(tmp_path: Path) -> None:
+    """Being a directory only means gitlink for a path *git named*, and git names
+    no plain directory among a project's files — empty or full of source.
+
+    Without that, every scan of a project with a subdirectory would announce a
+    submodule it does not have.
+    """
+    project = repository(tmp_path / "project")
+    committed(project, project / "src" / "a.py")
+    (project / "empty").mkdir()
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == ["src/a.py"]
+    assert scanned.notices == []
+
+
+@A_MACHINE_THAT_CAN_MAKE_A_SYMLINK
+def test_a_tracked_symlink_to_a_directory_is_not_a_submodule(tmp_path: Path) -> None:
+    """The everyday shape that a filesystem test gets wrong.
+
+    ``Path.is_dir()`` follows symlinks, so a tracked symlink to a directory
+    answers it exactly as a submodule does — and a symlinked ``node_modules`` is
+    pnpm's ordinary layout, the very thing #142's reporter has. Git records the
+    two differently (mode ``120000`` against ``160000``), so the index is asked
+    and the disk is not.
+
+    Both directions are covered: a link pointing inside the project and one
+    pointing out of it, since only the second leaves the project's own tree.
+    """
+    outside = tmp_path / "elsewhere"
+    written(outside / "dep.py")
+    project = repository(tmp_path / "project")
+    committed(project, project / "src" / "a.py")
+    written(project / "inside" / "b.py")
+    tracked_symlink(project, "node_modules", outside)
+    tracked_symlink(project, "linked_in", project / "inside")
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert (project / "node_modules").is_dir()  # the situation under test
+    assert (project / "linked_in").is_dir()
+    assert scanned.notices == []
+
+
+def test_a_plain_tracked_file_is_not_a_submodule(tmp_path: Path) -> None:
+    """Mode ``100644``, the commonest thing in any repository, says nothing."""
+    project = repository(tmp_path / "project")
+    committed(project, project / "src" / "a.py")
+    scanned = _scope(["--all"], project, Config(files=_PY_SOURCE))
+
+    assert scanned.files == ["src/a.py"]
+    assert scanned.notices == []
+
+

--- a/tests/test_which_issues_survive_a_merge.py
+++ b/tests/test_which_issues_survive_a_merge.py
@@ -1,0 +1,143 @@
+"""Which issues survive a merge: what makes two of them one observation (#140).
+
+An issue is identified by its ``key`` and **the place it names**, and by nothing
+either tool said in its own voice — ``source`` and ``message`` disagree between
+two sensors precisely because they are two tools. Every field of that place is
+load-bearing, and each case below fails if its own is dropped from
+``PLACE_FIELDS``.
+
+Which findings are merged in the first place is
+``test_merging_findings_of_one_smell.py``'s subject, and why a *single*
+finding's issues are never touched is
+``test_a_sensors_own_issues_are_never_second_guessed.py``'s.
+"""
+
+from __future__ import annotations
+
+from habit_hooks.merged_findings import merged
+
+ONE_GUIDE = "guides/the-one.md"
+
+
+def _same_guide(finding: dict) -> str:
+    return ONE_GUIDE
+
+
+def _finding(smell: str, issues: list[dict], **rest: object) -> dict:
+    return {"smell": smell, "details": {}, "issues": issues, **rest}
+
+
+def _at(file: str, **details: object) -> dict:
+    return {"key": file, "details": {"file": file, **details}}
+
+
+def test_two_sensors_naming_one_place_leave_one_issue() -> None:
+    """Neither sensor's own words count towards the identity — they disagree on
+    ``source`` and ``message`` precisely because they are two tools."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py", source="eslint:max-lines")]),
+        _finding("oversized-file", [_at("src/a.py", lines=260, source="line-count")]),
+    ]
+
+    assert merged(findings, _same_guide)[0]["issues"] == [
+        _at("src/a.py", source="eslint:max-lines")
+    ]
+
+
+def test_a_line_nobody_stated_is_absent_rather_than_a_value() -> None:
+    """One sensor spells the absence ``null`` and the other omits the key. Both
+    mean the same place, and an identity built by stringifying would read the
+    first as ``'None'`` and keep them apart."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py", line=None, column=None)]),
+        _finding("oversized-file", [_at("src/a.py")]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 1
+
+
+def test_one_key_found_in_two_files_is_two_issues() -> None:
+    """``deptry`` keys by module and ``knip`` by export name, so a key says
+    nothing about where — one ``default`` export per file is two things to
+    delete."""
+    findings = [
+        _finding("unused-export", [{"key": "default", "details": {"file": "src/a.ts"}}]),
+        _finding("unused-export", [{"key": "default", "details": {"file": "src/b.ts"}}]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 2
+
+
+def test_two_clones_starting_in_different_places_are_two_duplications() -> None:
+    """A jscpd occurrence names a range rather than a line, and every other fact
+    about two clones of one file is identical."""
+    findings = [
+        _finding("duplicated-code", [_at("src/a.py", startLine=10, endLine=30)]),
+        _finding("duplicated-code", [_at("src/a.py", startLine=100, endLine=30)]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 2
+
+
+def test_two_clones_of_different_lengths_are_two_duplications() -> None:
+    """One block duplicated elsewhere in full and elsewhere again in part starts
+    at the same line twice; only where it ends tells the two apart."""
+    findings = [
+        _finding("duplicated-code", [_at("src/a.py", startLine=10, endLine=30)]),
+        _finding("duplicated-code", [_at("src/a.py", startLine=10, endLine=90)]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 2
+
+
+def test_two_findings_on_one_line_at_different_columns_are_two_issues() -> None:
+    """Two ``any``s on one line are two things to fix, and eslint keys both by
+    the file — the column is the only thing telling them apart."""
+    findings = [
+        _finding("explicit-any", [_at("src/a.ts", line=5, column=11)]),
+        _finding("explicit-any", [_at("src/a.ts", line=5, column=30)]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 2
+
+
+def test_an_issue_that_states_no_details_at_all_still_reports() -> None:
+    """``details`` is conventional, not required — a sensor may key an issue and
+    say nothing else about it."""
+    findings = [
+        _finding("unused-dependency", [{"key": "requests"}]),
+        _finding("unused-dependency", [{"key": "urllib3"}]),
+    ]
+
+    assert [issue["key"] for issue in merged(findings, _same_guide)[0]["issues"]] == [
+        "requests",
+        "urllib3",
+    ]
+
+
+def test_two_places_in_one_file_are_two_issues() -> None:
+    """A project's own sensor emitting a catalogued smell merges with the
+    shipped one's finding (docs/authoring-plugins.spec.md), and both key an
+    issue by its file — so two complex functions in that file are told apart by
+    their line and nothing else."""
+    findings = [
+        _finding("high-complexity", [_at("src/a.py", line=12)]),
+        _finding("high-complexity", [_at("src/a.py", line=88)]),
+    ]
+
+    assert len(merged(findings, _same_guide)[0]["issues"]) == 2
+
+
+def test_a_third_finding_is_weighed_against_the_second_as_well_as_the_first() -> None:
+    """Everything already gathered is what a later finding is checked against,
+    not the first finding alone. Here only the second and third name one file,
+    and counting it twice tells the reader to fix something already listed."""
+    findings = [
+        _finding("oversized-file", [_at("src/a.py", source="eslint:max-lines")]),
+        _finding("oversized-file", [_at("src/b.py", source="line-count")]),
+        _finding("oversized-file", [_at("src/b.py", source="ours")]),
+    ]
+
+    issues = merged(findings, _same_guide)[0]["issues"]
+
+    assert [issue["key"] for issue in issues] == ["src/a.py", "src/b.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "habit-hooks"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -150,27 +150,27 @@ dev = [
 
 [[package]]
 name = "habit-hooks-generic"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "plugins/generic" }
 
 [[package]]
 name = "habit-hooks-java"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "plugins/java" }
 
 [[package]]
 name = "habit-hooks-php"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "plugins/php" }
 
 [[package]]
 name = "habit-hooks-python"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "plugins/python" }
 
 [[package]]
 name = "habit-hooks-typescript"
-version = "1.4.0rc2"
+version = "1.4.0rc3"
 source = { editable = "plugins/typescript" }
 
 [[package]]


### PR DESCRIPTION
Draft, opened to run CI on the Windows leg before tagging `v1.4.0rc3`.

Fixes #142, #140, #143, plus a `[runners]` traceback and two false cleans found on the way.

Local: 956 passed, 2 skipped, ruff clean, `uv run habit-hooks --all` exit 0.

*Opened by Claude on Ivett's behalf, while she is away.*