### PR TITLE
fix(snooze): let --snooze re-affirm a lapsed entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -799,8 +799,8 @@ commits lost). Give every git-backed section a
 `✏️GIT_CEILING_DIRECTORIES` = `$PWD/..` step next to its `git init`, as
 `## Scope` → `### Git-derived scopes` in habit-sensors.spec.md does: git's
 upward walk then stops at the case directory and the case can only ever see the
-repository it built. Older git-backed cases (habit-snooze.spec.md's
-`## --until-changed`, and two in habit-sensors.spec.md) still lack it.
+repository it built. Two older git-backed cases in habit-sensors.spec.md still
+lack it.
 
 ### `git diff --name-only` answers from the repo root, and quotes odd names
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -206,6 +206,9 @@ mapping, config validation) are resolved and recorded above / in
   ever encoded content in a key, so the ratchet simply vanished. Keeping the
   index keyed on `key` alone and moving the question into the drop decision
   leaves the index format and `--prune` untouched.
+  _(SUPERSEDED by "A snooze records what it was granted against" below — the
+  index now records content per anchor and `--prune` reaps anchors too. It is
+  still keyed on `key` alone.)_
 - **An issue is anchored to `details.file`, falling back to `key`.** A sensor
   keys by whatever groups issues best — `deptry` by module, `knip` by export —
   so the key is not always a path; all eight shipped sensors carry
@@ -384,7 +387,8 @@ mapping, config validation) are resolved and recorded above / in
 - **A malformed index fails by name.** `load_index` was `json.loads` with no
   type check: `null` iterated as `None`, a bare `"src/a.py"` iterated per
   character (a silent index of nothing), an object survived only to be flattened
-  on the next `--snooze`. It now demands a JSON list of strings and raises
+  on the next `--snooze`. It now demands a JSON list of strings _(AMENDED below
+  — a list of entries, each a key or a key with its recorded anchors)_ and raises
   `SnoozeError` naming the file — a checked-in file a human edits must not fail
   as a traceback or, worse, quietly. It **exits 2**, not 1: the index is part of
   the tool's own inputs, so a broken one is #103's "failure of the tool itself",
@@ -461,3 +465,58 @@ mapping, config validation) are resolved and recorded above / in
   `unused-import`, `unused-file`, `unused-dependency`, `unused-class-member` are
   all enforced). A project that wants it advisory sets
   `[smells.unused-export] severity = "suggested"`.
+
+## A snooze records what it was granted against (2026-09, issue #163, agent decision)
+
+Supersedes "leaves the index format and `--prune` untouched" under #80 above: both change here.
+
+- **Re-affirming is `--snooze` itself, not a new flag** _(Ivett's call)_. Running it again on an
+  entry whose file changed records the file as it now stands, and the finding is dropped until the
+  next edit. The issue had proposed a `--reaffirm`; it was refused as a new option for behaviour
+  the existing one should have.
+- **An entry is a key and the anchors it was granted against** — `{"key": …, "anchors": {"<file>":
+  "sha256:…"}}` — and an entry recording nothing stays a bare key string, so an index written
+  before this loads and rewrites unchanged and a project migrates one `--snooze` at a time.
+- **A lapse needs both halves: git says the anchor changed, *and* the recorded content no longer
+  matches.** Content alone would break the promise recorded under #80 — work landed on the base ref
+  afterwards lapses nothing — because a branch that never touched the file still sees the content
+  someone else landed. The git half is what keeps that branch alone; the index half is the only
+  thing a re-run of `--snooze` can change, which is why a bare path could never re-affirm anything.
+- **One digest per anchor, not per key.** A key can cover several files (`deptry` keys by module,
+  `knip` by export), and the pre-#163 rule already decided per issue against that issue's own
+  anchor. A single digest per key could only describe one of them, and *which* one fell out of the
+  order the sensor emitted its issues — a checked-in file that differs by sensor output order. It
+  also suppressed new debt: a key that becomes aliased on day two carries a digest recorded on day
+  one, and the file that has only just started reporting the smell inherits an affirmation nobody
+  gave it. Affirmation is therefore per `(key, anchor)`, which is what the rule always was.
+- **The digest normalises `\r\n` and nothing else, deliberately one notch more forgiving than
+  `git diff`.** Measured: under `core.autocrlf` git reports nothing for a CRLF-only rewrite;
+  without it git reports the file. Hashing the bytes on disk would lapse an affirmation made on a
+  CRLF checkout the moment an LF one read the index, and the index is checked in precisely so the
+  answer travels. A line-ending-only rewrite is not the debt the ratchet exists to surface.
+- **Rejected: `git hash-object`.** It would honour `eol=` and other clean filters and would be the
+  most faithful to "let the tool answer", but `--snooze` must work with no repository at all
+  (habit-snooze.spec.md snoozes without a `git init`), and a spec case without
+  `GIT_CEILING_DIRECTORIES` would read *this* checkout's attributes.
+- **Every `--snooze` records, plain `snooze` included.** `--snooze --until-changed` is already a
+  usage error (#86), so there is no flag to key the recording off. A project that never opted into
+  the ratchet therefore gains the new entry shape too — and with it the read break below.
+- **The break is forwards-only, and loud.** 1.5.0's `_parse_index` refuses any entry this version
+  records into, including a half-migrated index, with `SnoozeError` and exit 2. A team where one
+  person upgrades breaks everyone else's runs, and CI's, until they upgrade. It fails by name and
+  names the file, which is the right direction to fail, but it is a minor-version break.
+- **A key written twice is refused when the two disagree, and only then.** Loading into a mapping
+  keeps the last, so a bare duplicate beside a recorded one drops the recording with the order in
+  the file deciding — the "survived only to be flattened on the next write" class #94 parses
+  strictly to prevent. Two entries that agree lose nothing, so a plain `["a", "a"]` stays legal as
+  it always was, and nothing that 1.5.0 reads is refused here. The same rule covers a name written
+  twice inside one object, which `json` would otherwise resolve last-wins in silence.
+- **Only an anchor git called changed is hashed.** The other half of the rule decides every other
+  one without it, so asking them all would read and hash every snoozed file in the project on the
+  ordinary run where git flagged none — in a transform that runs inside a hook loop, and whose git
+  half is batched into a single call for exactly that reason. The narrowing lives on `Lapse`, which
+  already holds git's answer, so the transform's argument count is unchanged.
+- **Out of scope, deliberately:** a `reason` field and a per-smell key (both from the issue's own
+  proposal, neither needed for the ruling given), and restricting the recording to
+  `oversized-file` — the transformer works on keys and knows nothing of the smell vocabulary,
+  which is `catalogue.py`'s; the property that matters is structural, not a name.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -505,6 +505,10 @@ Supersedes "leaves the index format and `--prune` untouched" under #80 above: bo
   records into, including a half-migrated index, with `SnoozeError` and exit 2. A team where one
   person upgrades breaks everyone else's runs, and CI's, until they upgrade. It fails by name and
   names the file, which is the right direction to fail, but it is a minor-version break.
+- **`--prune` reaps a stale anchor the same way it reaps a key.** An anchor goes stale inside an
+  entry that is still live — one of two files deleted while the key is still reported through the
+  other — and pruning by key alone would leave it recorded forever. Its contract is unchanged, and
+  the #94 refusal to empty a populated index on a run that measured nothing is untouched.
 - **A key written twice is refused when the two disagree, and only then.** Loading into a mapping
   keeps the last, so a bare duplicate beside a recorded one drops the recording with the order in
   the file deciding — the "survived only to be flattened on the next write" class #94 parses

--- a/docs/habit-snooze.spec.md
+++ b/docs/habit-snooze.spec.md
@@ -470,7 +470,7 @@ habit-snooze --list 2>&1 >/dev/null | sed 's| /.*/\.habit-hooks/| .habit-hooks/|
 
 🖥️ ❌ 2
 ```text
-habit-snooze: .habit-hooks/snooze.json: expected a JSON list of string keys, got an object
+habit-snooze: .habit-hooks/snooze.json: expected a JSON list of snoozed entries, got an object
 ```
 
 ## `--until-changed` keeps a snooze only while its file is unchanged

--- a/docs/habit-snooze.spec.md
+++ b/docs/habit-snooze.spec.md
@@ -219,6 +219,12 @@ takes the key out of the index. That is deliberate — a project upgrading must
 not find its snoozes re-arming by themselves — and it is the whole difference
 from [`--until-changed`](#--until-changed-keeps-a-snooze-only-while-its-file-is-unchanged)
 below. The file here is committed and then edited, and the issue stays dropped.
+The ceiling keeps `git init` from finding habit-hooks' own checkout above it.
+
+✏️GIT_CEILING_DIRECTORIES
+```text
+$PWD/..
+```
 
 📄src/x.ts
 ```ts
@@ -511,7 +517,15 @@ snooze permanent again, silently, which is the bug this transformer exists to
 fix.
 
 Every case below inherits this repository: `src/x.ts` and `src/other.ts`
-committed on `main`, with `src/x.ts` snoozed.
+committed on `main`, with `src/x.ts` snoozed. The ceiling is what keeps it
+*this* repository: the spec harness runs each case inside habit-hooks' own
+checkout, and without it git walks up and answers about habit-hooks — a case
+that branches would then rename a ref in the checkout you are reading.
+
+✏️GIT_CEILING_DIRECTORIES
+```text
+$PWD/..
+```
 
 📄src/x.ts
 ```ts

--- a/docs/habit-snooze.spec.md
+++ b/docs/habit-snooze.spec.md
@@ -76,6 +76,15 @@ habit-snooze | jq .
 `--snooze` reads the findings on stdin and adds each issue's `key` to the index.
 `--list` then shows what is snoozed.
 
+An entry also records the content of each file the key is anchored to —
+`{"key": "src/x.ts", "anchors": {"src/x.ts": "sha256:…"}}` — which is what lets a
+later `--snooze`
+[re-affirm it](#--snooze-re-affirms-a-lapsed-entry-until-the-next-change). It
+remembers per file, because a key does not always stand for exactly one
+([sensor-interface.spec.md](sensor-interface.spec.md)). A key with nothing to
+record — an anchor that is no file on disk — is written as a bare string
+instead. `--list` shows the keys either way.
+
 ⌨️
 ```json
 [
@@ -561,6 +570,89 @@ uncommitted edit, and that alone re-surfaces the issue.
 
 ```bash
 printf 'export const extra = 1;\n' >> src/x.ts
+```
+
+⌨️
+```json
+[
+  {
+    "smell": "oversized-file",
+    "details": { "maxAllowed": 200 },
+    "issues": [
+      { "key": "src/x.ts", "details": { "file": "src/x.ts", "lines": 251 } }
+    ]
+  }
+]
+```
+
+```bash
+habit-snooze --until-changed | jq -c '[.[].issues[].key]'
+```
+
+🖥️ ✅
+```json
+["src/x.ts"]
+```
+
+### `--snooze` re-affirms a lapsed entry until the next change
+
+The file lapsed above, and sometimes the answer is still the one given last
+time. Running `--snooze` again records the entry against the file as it now
+stands, and the finding is dropped for the rest of this branch. The index keeps
+that answer, so a teammate's checkout and CI honour it too.
+
+Note that `--snooze` re-affirms every lapsed entry the run reports, not only the
+one you had in mind: it renews what it is fed.
+
+```bash
+printf 'export const extra = 1;\n' >> src/x.ts
+```
+
+⌨️
+```json
+[
+  {
+    "smell": "oversized-file",
+    "details": { "maxAllowed": 200 },
+    "issues": [
+      { "key": "src/x.ts", "details": { "file": "src/x.ts", "lines": 251 } }
+    ]
+  }
+]
+```
+
+```bash
+habit-snooze --snooze
+```
+
+The finding is gone again, and the file was never changed back.
+
+⌨️
+```json
+[
+  {
+    "smell": "oversized-file",
+    "details": { "maxAllowed": 200 },
+    "issues": [
+      { "key": "src/x.ts", "details": { "file": "src/x.ts", "lines": 251 } }
+    ]
+  }
+]
+```
+
+```bash
+habit-snooze --until-changed | jq -c '[.[].issues[].key]'
+```
+
+🖥️ ✅
+```json
+[]
+```
+
+The next edit asks again: what was affirmed was that state of the file.
+
+```bash
+printf 'export const more = 2;\n' >> src/x.ts
 ```
 
 ⌨️

--- a/docs/habit-snooze.spec.md
+++ b/docs/habit-snooze.spec.md
@@ -326,7 +326,8 @@ deleted — is stale, and `--prune` drops it. But `--prune` must read the findin
 stripped every snoozed issue, so a naive `--prune` would see none of them and
 empty the whole index (#94). The documented pipeline therefore runs
 `habit-sensors --no-snooze`, so `--prune` compares the index against everything
-the run still finds — snoozed or not.
+the run still finds — snoozed or not. It reaps stale **anchors** the same way: a
+key can stay live through one file while another it recorded is gone.
 
 These cases drive that real pipeline through a stub sensor rather than hand-fed
 findings, so the bypass that hid the bug cannot come back. Discovery is opt-in

--- a/src/habit_hooks/snooze.py
+++ b/src/habit_hooks/snooze.py
@@ -23,6 +23,7 @@ from .changed_files import changed_against_base
 from .cli import EXIT_TOOL_ERROR, add_version_flag, run_console
 from .config import load_config
 from .snooze_index import INDEX_PATH, SnoozeError, load_index, save_index
+from .snooze_lapse import anchor_file, finding_keys, snoozed_anchors
 
 __all__ = ["INDEX_PATH", "SnoozeError", "load_index", "main", "save_index"]
 
@@ -30,19 +31,6 @@ __all__ = ["INDEX_PATH", "SnoozeError", "load_index", "main", "save_index"]
 # --no-snooze` strips them so `--prune` can compare the index against a
 # snooze-free view of the run instead of one snooze already emptied (#94).
 SNOOZE_TRANSFORMERS = frozenset({"snooze", "snooze-until-changed"})
-
-
-def finding_keys(findings: list[dict]) -> list[str]:
-    return [issue["key"] for finding in findings for issue in finding["issues"]]
-
-
-def anchor_file(issue: dict) -> str:
-    """The file an issue's snooze is anchored to: its ``details.file``, else its key.
-
-    A sensor keys an issue by whatever groups it best — a module or export name,
-    not always a path — so the file to compare comes from the details bag.
-    """
-    return issue.get("details", {}).get("file", issue["key"])
 
 
 def transform(
@@ -72,16 +60,6 @@ def transform(
 
 def _still_snoozed(issue: dict, snoozed: set[str], lapsed: Collection[str]) -> bool:
     return issue["key"] in snoozed and anchor_file(issue) not in lapsed
-
-
-def snoozed_anchors(findings: list[dict], snoozed: set[str]) -> set[str]:
-    """The files the snoozed issues sit in — where a lapse could apply."""
-    return {
-        anchor_file(issue)
-        for finding in findings
-        for issue in finding["issues"]
-        if issue["key"] in snoozed
-    }
 
 
 def read_findings() -> list[dict]:

--- a/src/habit_hooks/snooze.py
+++ b/src/habit_hooks/snooze.py
@@ -16,14 +16,13 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Collection
 from pathlib import Path
 
 from .changed_files import changed_against_base
 from .cli import EXIT_TOOL_ERROR, add_version_flag, run_console
 from .config import load_config
 from .snooze_index import INDEX_PATH, SnoozeError, load_index, save_index
-from .snooze_lapse import anchor_file, finding_keys, snoozed_anchors
+from .snooze_lapse import Lapse, anchor_file, finding_keys, renewed, snoozed_anchors
 
 __all__ = ["INDEX_PATH", "SnoozeError", "load_index", "main", "save_index"]
 
@@ -34,12 +33,12 @@ SNOOZE_TRANSFORMERS = frozenset({"snooze", "snooze-until-changed"})
 
 
 def transform(
-    findings: list[dict], snoozed: set[str], lapsed: Collection[str] = frozenset()
+    findings: list[dict], snoozed: set[str], lapse: Lapse = Lapse()
 ) -> list[dict]:
     """Drop snoozed issues, and any finding whose last issue we just dropped.
 
-    ``snoozed`` holds keys, ``lapsed`` the files whose snooze no longer applies:
-    an issue anchored to one of those changed, so its debt is due again.
+    ``snoozed`` holds keys; ``lapse`` says which of them no longer apply, because
+    the file an issue is anchored to changed and nothing re-affirmed it.
 
     A finding that arrives with no issues is passed through rather than dropped:
     nothing in it was snoozed. That keeps an empty index a true no-op, which
@@ -50,7 +49,7 @@ def transform(
         issues = [
             issue
             for issue in finding["issues"]
-            if not _still_snoozed(issue, snoozed, lapsed)
+            if not _still_snoozed(issue, snoozed, lapse)
         ]
         snoozed_them_all = finding["issues"] and not issues
         if not snoozed_them_all:
@@ -58,8 +57,8 @@ def transform(
     return kept
 
 
-def _still_snoozed(issue: dict, snoozed: set[str], lapsed: Collection[str]) -> bool:
-    return issue["key"] in snoozed and anchor_file(issue) not in lapsed
+def _still_snoozed(issue: dict, snoozed: set[str], lapse: Lapse) -> bool:
+    return issue["key"] in snoozed and lapse.spares(issue["key"], anchor_file(issue))
 
 
 def read_findings() -> list[dict]:
@@ -74,8 +73,7 @@ def run(args: argparse.Namespace, project_dir: Path) -> int:
         return 0
     if args.snooze:
         index = load_index(project_dir)
-        keys = finding_keys(read_findings())
-        save_index(index | {key: index.get(key, {}) for key in keys}, project_dir)
+        save_index(renewed(index, read_findings(), project_dir), project_dir)
         return 0
     if args.prune:
         return _prune(project_dir)
@@ -114,13 +112,17 @@ def _write_transformed(
     not a silent fall back to ``.habit-hooks/config.toml`` (#86).
     """
     findings = read_findings()
-    snoozed = set(load_index(project_dir))
-    lapsed: set[str] = set()
+    index = load_index(project_dir)
+    lapse = Lapse()
     if until_changed:
-        base_ref = load_config(project_dir, config_path).scope.branchBase
-        anchors = snoozed_anchors(findings, snoozed)
-        lapsed = changed_against_base(anchors, project_dir, base_ref)
-    sys.stdout.write(json.dumps(transform(findings, snoozed, lapsed)) + "\n")
+        lapse = Lapse(
+            changed_against_base(
+                snoozed_anchors(findings, set(index)),
+                project_dir,
+                load_config(project_dir, config_path).scope.branchBase,
+            )
+        ).affirming(index, findings, project_dir)
+    sys.stdout.write(json.dumps(transform(findings, set(index), lapse)) + "\n")
     return 0
 
 

--- a/src/habit_hooks/snooze.py
+++ b/src/habit_hooks/snooze.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from .changed_files import changed_against_base
 from .cli import EXIT_TOOL_ERROR, add_version_flag, run_console
 from .config import load_config
-from .snooze_index import INDEX_PATH, SnoozeError, load_index, save_index
-from .snooze_lapse import Lapse, anchor_file, finding_keys, renewed, snoozed_anchors
+from .snooze_index import INDEX_PATH, Anchors, SnoozeError, load_index, save_index
+from .snooze_lapse import Lapse, anchor_file, anchors_by_key, renewed, snoozed_anchors
 
 __all__ = ["INDEX_PATH", "SnoozeError", "load_index", "main", "save_index"]
 
@@ -81,14 +81,20 @@ def run(args: argparse.Namespace, project_dir: Path) -> int:
 
 
 def _prune(project_dir: Path) -> int:
-    """Drop index keys the latest run no longer reports — but never on an empty
-    run. Empty findings mean "nothing was measured" (an empty scope, or a
-    snooze-filtered pipe), not "every exemption is obsolete"; emptying the whole
-    index on that is the false-clean class of #78/#84, so it is refused (#94).
-    The run must be fed snooze-free (`habit-sensors --no-snooze`), else every
-    still-violating key is missing from stdin and would be pruned away.
+    """Drop index keys the latest run no longer reports, and within a key it
+    keeps, the anchors it no longer reports either — a key can stay live through
+    one file while another it recorded is gone. A key whose anchors have all
+    moved (a rename, a split) keeps the key and loses its recordings, falling
+    back to pre-#163 behaviour until the next ``--snooze``.
+
+    Never on an empty run, though. Empty findings mean "nothing was measured" (an
+    empty scope, or a snooze-filtered pipe), not "every exemption is obsolete";
+    emptying the whole index on that is the false-clean class of #78/#84, so it
+    is refused (#94). The run must be fed snooze-free (`habit-sensors
+    --no-snooze`), else every still-violating key is missing from stdin and would
+    be pruned away.
     """
-    present = set(finding_keys(read_findings()))
+    present = anchors_by_key(read_findings())
     index = load_index(project_dir)
     if index and not present:
         sys.stderr.write(
@@ -98,8 +104,13 @@ def _prune(project_dir: Path) -> int:
             "Index left unchanged.\n"
         )
         return 1
-    save_index({key: index[key] for key in index if key in present}, project_dir)
+    kept = {key: _reported(index[key], present[key]) for key in index if key in present}
+    save_index(kept, project_dir)
     return 0
+
+
+def _reported(recorded: Anchors, anchors: set[str]) -> Anchors:
+    return {anchor: content for anchor, content in recorded.items() if anchor in anchors}
 
 
 def _write_transformed(

--- a/src/habit_hooks/snooze.py
+++ b/src/habit_hooks/snooze.py
@@ -73,7 +73,9 @@ def run(args: argparse.Namespace, project_dir: Path) -> int:
             sys.stdout.write(key + "\n")
         return 0
     if args.snooze:
-        save_index(load_index(project_dir) + finding_keys(read_findings()), project_dir)
+        index = load_index(project_dir)
+        keys = finding_keys(read_findings())
+        save_index(index | {key: index.get(key, {}) for key in keys}, project_dir)
         return 0
     if args.prune:
         return _prune(project_dir)
@@ -98,7 +100,7 @@ def _prune(project_dir: Path) -> int:
             "Index left unchanged.\n"
         )
         return 1
-    save_index([key for key in index if key in present], project_dir)
+    save_index({key: index[key] for key in index if key in present}, project_dir)
     return 0
 
 

--- a/src/habit_hooks/snooze_index.py
+++ b/src/habit_hooks/snooze_index.py
@@ -3,6 +3,11 @@
 Split from ``snooze.py`` so the index file I/O — parsing a JSON file a human
 edits, and replacing it without tearing under concurrent hook runs — lives apart
 from the transform and its CLI (#94).
+
+An entry is a key and the anchors it was granted against, each recorded with the
+content that file held at the time (#163). An entry that records nothing stays a
+bare key, so an index written before that keeps loading and a project migrates
+one ``--snooze`` at a time.
 """
 
 from __future__ import annotations
@@ -11,7 +16,33 @@ import json
 import os
 from pathlib import Path
 
+from attrs import frozen
+
 INDEX_PATH = Path(".habit-hooks") / "snooze.json"
+
+ENTRY_FIELDS = frozenset({"key", "anchors"})
+
+# The anchor files an entry was granted against, each mapped to the content it
+# held then. Empty for an entry written before #163, and for one whose anchor is
+# no file to read.
+Anchors = dict[str, str]
+
+# What `load_index` hands the rest of the tool: every snoozed key, with what it
+# was granted against.
+Index = dict[str, Anchors]
+
+
+@frozen
+class Entry:
+    """One line of the index as written: a key, and what that line recorded.
+
+    Distinct from `Index` because a list of these can hold the same key twice
+    and a mapping cannot. Collapsing them is the step where a recording is
+    lost, so a duplicate has to be visible before it happens.
+    """
+
+    key: str
+    anchors: Anchors
 
 
 class SnoozeError(Exception):
@@ -19,43 +50,132 @@ class SnoozeError(Exception):
     name rather than as a traceback or, worse, a silent misread (#94)."""
 
 
-def load_index(project_dir: Path) -> list[str]:
+def load_index(project_dir: Path) -> Index:
     path = project_dir / INDEX_PATH
     if not path.exists():
-        return []
+        return {}
     return _parse_index(path)
 
 
-def _parse_index(path: Path) -> list[str]:
-    """The index is a JSON list of string keys; anything else fails by name.
+def _parse_index(path: Path) -> Index:
+    """The index is a JSON list of entries; anything else fails by name.
 
     Left untyped, ``null`` iterated as ``None``, a bare ``"src/a.py"`` iterated
     per character, and ``{"key": "reason"}`` survived only to be flattened to a
     bare list on the next ``--snooze`` — each a silent way to mean nothing.
     """
+    data = _parse_json(path)
+    if not isinstance(data, list):
+        raise SnoozeError(
+            f"{path}: expected a JSON list of snoozed entries, got {_describe(data)}"
+        )
+    entries = [_entry(path, item) for item in data]
+    _reject_a_conflicting_duplicate(path, entries)
+    return {entry.key: entry.anchors for entry in entries}
+
+
+def _parse_json(path: Path) -> object:
+    """The file as JSON, refusing a name written twice inside one object.
+
+    ``json`` keeps the last of two members sharing a name, so an anchor pasted
+    twice with two different digests would load as one of them and say nothing.
+    That is the refusal below, one level further in.
+    """
+
+    def one_name_each(pairs: list[tuple[str, object]]) -> dict:
+        names = [name for name, _ in pairs]
+        repeated = next((name for name in names if names.count(name) > 1), None)
+        if repeated is not None:
+            raise SnoozeError(
+                f'{path}: expected each name once, got "{repeated}" more than once'
+            )
+        return dict(pairs)
+
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text, object_pairs_hook=one_name_each)
     except json.JSONDecodeError as exc:
         raise SnoozeError(f"{path}: not valid JSON ({exc})") from exc
-    if not (isinstance(data, list) and all(isinstance(key, str) for key in data)):
-        raise SnoozeError(
-            f"{path}: expected a JSON list of string keys, got {_describe(data)}"
-        )
-    return data
 
 
-def _describe(data: object) -> str:
-    if isinstance(data, list):
-        return "a list with a non-string entry"
-    return {dict: "an object", str: "a bare string", type(None): "null"}.get(
-        type(data), type(data).__name__
+def _entry(path: Path, item: object) -> Entry:
+    """One entry: a bare key, or that key with the anchors it was granted against.
+
+    A key beside a field the index has no meaning for is refused rather than
+    read and dropped on the next write — the flattening above, in the shape it
+    takes now that an entry can be an object.
+    """
+    if isinstance(item, str):
+        return Entry(item, {})
+    if _is_entry(item):
+        return Entry(item["key"], item.get("anchors", {}))
+    raise SnoozeError(
+        f"{path}: expected each entry to be a snoozed key, or an object with "
+        f'"key" and an optional "anchors", got {_describe(item)}'
     )
 
 
-def save_index(keys: list[str], project_dir: Path) -> None:
+def _reject_a_conflicting_duplicate(path: Path, entries: list[Entry]) -> None:
+    """Two entries for one key are refused unless they say the same thing.
+
+    Loading into a mapping keeps the last, so a bare duplicate beside a recorded
+    one drops the recording and reverts that entry to the behaviour it had before
+    it recorded anything — silently, with the order in the file deciding. Two
+    entries that agree cannot lose anything, so a plain ``["a", "a"]`` was always
+    legal and still is.
+    """
+    seen: Index = {}
+    for entry in entries:
+        if seen.setdefault(entry.key, entry.anchors) != entry.anchors:
+            raise SnoozeError(
+                f'{path}: expected each key once, got "{entry.key}" twice '
+                "recording different anchors"
+            )
+
+
+def _is_entry(item: object) -> bool:
+    return (
+        isinstance(item, dict)
+        and isinstance(item.get("key"), str)
+        and _is_anchors(item.get("anchors", {}))
+        and not set(item) - ENTRY_FIELDS
+    )
+
+
+def _is_anchors(anchors: object) -> bool:
+    return isinstance(anchors, dict) and all(
+        isinstance(anchor, str) and isinstance(content, str)
+        for anchor, content in anchors.items()
+    )
+
+
+def _describe(data: object) -> str:
+    return {
+        dict: "an object",
+        list: "a list",
+        str: "a bare string",
+        bool: "a boolean",
+        int: "a number",
+        float: "a number",
+        type(None): "null",
+    }.get(type(data), type(data).__name__)
+
+
+def save_index(entries: Index, project_dir: Path) -> None:
     path = project_dir / INDEX_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    _replace_atomically(path, json.dumps(sorted(set(keys))) + "\n")
+    written = [_written(key, entries[key]) for key in sorted(entries)]
+    _replace_atomically(path, json.dumps(written) + "\n")
+
+
+def _written(key: str, anchors: Anchors) -> str | dict:
+    """An entry recording nothing is written as the bare key it was before #163,
+    so an index no ``--snooze`` has renewed keeps the shape its project knows.
+    Anchors are sorted along with the keys, so a file written on one line still
+    reviews as a stable diff."""
+    if not anchors:
+        return key
+    return {"key": key, "anchors": dict(sorted(anchors.items()))}
 
 
 def _replace_atomically(path: Path, content: str) -> None:

--- a/src/habit_hooks/snooze_lapse.py
+++ b/src/habit_hooks/snooze_lapse.py
@@ -1,12 +1,32 @@
-"""The terms a snooze is decided in: which key, and which file.
+"""What makes a snooze lapse, and what re-affirming one records (#163).
 
-Which key an issue is filed under, and which file that key is anchored to, is
-neither the transform and its CLI (``snooze.py``) nor the index file itself
-(``snooze_index.py``), and both sides need the answer. The module is named for
-what these terms serve: the rule that decides whether a snooze still holds.
+``snooze_index`` owns the file: reading it, refusing what it cannot mean, and
+replacing it without tearing. This module owns the rule read out of it, along
+with the terms that rule is expressed in, which came out of ``snooze.py`` where
+they sat beside the CLI. That division is the one ``rendering`` draws against
+``mapper``, and the dependency runs the same way: ``snooze_lapse`` →
+``snooze_index``.
+
+The rule has two halves. Git answers whether the branch changed the file, and
+only the index can answer whether that change is the one already judged — which
+is why nothing a re-run of ``--snooze`` wrote could clear a finding while an
+entry was a bare path.
+
+Both halves are asked per key *and* anchor: the pair is what the rule has always
+decided on, and a key is not always one file.
 """
 
 from __future__ import annotations
+
+import hashlib
+from collections.abc import Collection
+from pathlib import Path
+
+from attrs import evolve, frozen
+
+from .snooze_index import Anchors, Index
+
+CONTENT_ALGORITHM = "sha256"
 
 
 def finding_keys(findings: list[dict]) -> list[str]:
@@ -16,10 +36,30 @@ def finding_keys(findings: list[dict]) -> list[str]:
 def anchor_file(issue: dict) -> str:
     """The file an issue's snooze is anchored to: its ``details.file``, else its key.
 
-    A sensor keys an issue by whatever groups it best — a module or export name,
-    not always a path — so the file to compare comes from the details bag.
+    A sensor keys an issue by whatever groups it best, which is not always a path
+    — ``sensors.finding_paths.anchored`` names the same two, ``deptry`` keying by
+    module and ``knip`` by export name — so the file to record, and to compare,
+    comes from the details bag rather than from the key.
+
+    A ``file`` that is not a non-empty string reads as absent, the same reading
+    ``sensors.finding_paths._reported_file`` gives it. That stage lets such an
+    issue through rather than failing its sensor, so this one is reached with a
+    ``None`` or a number in there, and the anchor is now a path we open.
     """
-    return issue.get("details", {}).get("file", issue["key"])
+    file = issue.get("details", {}).get("file")
+    return file if isinstance(file, str) and file else issue["key"]
+
+
+def anchors_by_key(findings: list[dict]) -> dict[str, set[str]]:
+    """Every key the run reports, with the files it reports that key under.
+
+    Usually one file each; see ``anchor_file`` for when it is several.
+    """
+    anchors: dict[str, set[str]] = {}
+    for finding in findings:
+        for issue in finding["issues"]:
+            anchors.setdefault(issue["key"], set()).add(anchor_file(issue))
+    return anchors
 
 
 def snoozed_anchors(findings: list[dict], snoozed: set[str]) -> set[str]:
@@ -30,3 +70,109 @@ def snoozed_anchors(findings: list[dict], snoozed: set[str]) -> set[str]:
         for issue in finding["issues"]
         if issue["key"] in snoozed
     }
+
+
+def content_hash(path: Path) -> str | None:
+    """The digest of ``path``'s content, or ``None`` when it is no file to read.
+
+    Only ``\\r\\n`` is normalised away first, which makes this half of the rule
+    deliberately *more* forgiving than the other rather than identical to it.
+    Measured: under ``core.autocrlf`` git reports nothing for a CRLF-only
+    rewrite, without it git reports the file. Hashing the bytes on disk would
+    therefore lapse a snooze affirmed on a CRLF checkout the moment an LF one
+    read the index — and the index is checked in precisely so the answer
+    travels. So a line ending is the one difference this half forgives, which
+    costs little: a line-ending-only rewrite is not the new debt the ratchet
+    exists to surface.
+
+    An unreadable path records nothing rather than failing the run, the same
+    degrade ``changed_files`` gives a path git cannot place.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    digest = hashlib.sha256(raw.replace(b"\r\n", b"\n")).hexdigest()
+    return f"{CONTENT_ALGORITHM}:{digest}"
+
+
+@frozen
+class Lapse:
+    """Why a snooze may no longer hold: git's answer, and the index's own.
+
+    ``files`` are the anchor files this branch changed since the base ref;
+    ``affirmed`` the key-and-anchor pairs whose file still holds the content the
+    entry recorded for it.
+    """
+
+    files: Collection[str] = frozenset()
+    affirmed: Collection[tuple[str, str]] = frozenset()
+
+    def spares(self, key: str, anchor: str) -> bool:
+        """Whether a snooze on ``key``, anchored to ``anchor``, survives it."""
+        return anchor not in self.files or (key, anchor) in self.affirmed
+
+    def affirming(self, index: Index, findings: list[dict], project_dir: Path) -> Lapse:
+        """This lapse, told which of its changed anchors still hold what they recorded.
+
+        Only an anchor git called changed is asked, because ``spares`` decides
+        every other one without it. Asking them all would read and hash every
+        snoozed file in the project on the ordinary run where git flagged none —
+        in a transform that runs inside a hook loop, and whose git half is
+        batched into one call for that very reason.
+        """
+        affirmed = {
+            (key, anchor)
+            for key, anchor in _reported_pairs(findings)
+            if anchor in self.files and _holds(index.get(key, {}), anchor, project_dir)
+        }
+        return evolve(self, affirmed=affirmed)
+
+
+def renewed(index: Index, findings: list[dict], project_dir: Path) -> Index:
+    """``index``, with every reported key recording its anchors as they stand.
+
+    Every anchor the run reports, including one the key has no record of yet.
+    ``--snooze`` renews what it is fed, so the documented whole-project pipeline
+    affirms each file in the pipe — which is what fixing the existing
+    ``--snooze`` asks for, and the reason that pipeline is a blunt instrument
+    under the ratchet.
+
+    An anchor the run does *not* report is left alone: this run measured nothing
+    about it, and the file it describes may not even be in the current scope.
+    """
+    return index | {
+        key: index.get(key, {}) | _recorded(anchors, project_dir)
+        for key, anchors in anchors_by_key(findings).items()
+    }
+
+
+def _recorded(anchors: set[str], project_dir: Path) -> Anchors:
+    """The content each anchor holds now, skipping the ones that are no file.
+
+    A key may be anchored to something there is nothing to read; and a file
+    briefly unreadable is not an answer either, so it keeps whatever the entry
+    recorded before rather than losing its affirmation for a reason nobody chose.
+    """
+    fresh = {anchor: content_hash(project_dir / anchor) for anchor in anchors}
+    return {anchor: content for anchor, content in fresh.items() if content is not None}
+
+
+def _reported_pairs(findings: list[dict]) -> set[tuple[str, str]]:
+    """Every key the run reports, paired with the file it reports it under.
+
+    A pair, not a key: affirming the key would exempt a file nobody judged —
+    including one that has only just started reporting the smell, which is new
+    debt and the ratchet's whole point.
+    """
+    return {
+        (issue["key"], anchor_file(issue))
+        for finding in findings
+        for issue in finding["issues"]
+    }
+
+
+def _holds(recorded: Anchors, anchor: str, project_dir: Path) -> bool:
+    """Only an anchor that recorded something is asked, so an index written
+    before #163 reads no file at all."""
+    return anchor in recorded and recorded[anchor] == content_hash(project_dir / anchor)

--- a/src/habit_hooks/snooze_lapse.py
+++ b/src/habit_hooks/snooze_lapse.py
@@ -29,10 +29,6 @@ from .snooze_index import Anchors, Index
 CONTENT_ALGORITHM = "sha256"
 
 
-def finding_keys(findings: list[dict]) -> list[str]:
-    return [issue["key"] for finding in findings for issue in finding["issues"]]
-
-
 def anchor_file(issue: dict) -> str:
     """The file an issue's snooze is anchored to: its ``details.file``, else its key.
 

--- a/src/habit_hooks/snooze_lapse.py
+++ b/src/habit_hooks/snooze_lapse.py
@@ -1,0 +1,32 @@
+"""The terms a snooze is decided in: which key, and which file.
+
+Which key an issue is filed under, and which file that key is anchored to, is
+neither the transform and its CLI (``snooze.py``) nor the index file itself
+(``snooze_index.py``), and both sides need the answer. The module is named for
+what these terms serve: the rule that decides whether a snooze still holds.
+"""
+
+from __future__ import annotations
+
+
+def finding_keys(findings: list[dict]) -> list[str]:
+    return [issue["key"] for finding in findings for issue in finding["issues"]]
+
+
+def anchor_file(issue: dict) -> str:
+    """The file an issue's snooze is anchored to: its ``details.file``, else its key.
+
+    A sensor keys an issue by whatever groups it best — a module or export name,
+    not always a path — so the file to compare comes from the details bag.
+    """
+    return issue.get("details", {}).get("file", issue["key"])
+
+
+def snoozed_anchors(findings: list[dict], snoozed: set[str]) -> set[str]:
+    """The files the snoozed issues sit in — where a lapse could apply."""
+    return {
+        anchor_file(issue)
+        for finding in findings
+        for issue in finding["issues"]
+        if issue["key"] in snoozed
+    }

--- a/tests/snooze_project.py
+++ b/tests/snooze_project.py
@@ -1,0 +1,61 @@
+"""A project with files, an index and findings on stdin, for the #163 tests.
+
+The #163 test files build the same situation — a file on disk, a finding
+anchored to it, and ``--snooze`` fed through the real CLI — so the fixtures live
+here once rather than as copies drifting apart.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from habit_hooks.snooze import INDEX_PATH, parse_args, run
+
+
+def feed_stdin(monkeypatch: pytest.MonkeyPatch, findings: object) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(findings)))
+
+
+def finding(key: str, file: str | None = None) -> dict:
+    """One issue, anchored to ``file`` — or to its key, as a sensor may leave it."""
+    details = {"file": file} if file is not None else {}
+    return {
+        "smell": "oversized-file",
+        "details": {"maxAllowed": 200},
+        "issues": [{"key": key, "details": details}],
+    }
+
+
+def aliased(*files: str) -> list[dict]:
+    """One key over several files — see ``snooze_lapse.anchor_file`` for when a
+    sensor reports that."""
+    return [
+        {
+            "smell": "unused-dependency",
+            "details": {},
+            "issues": [{"key": "requests", "details": {"file": f}} for f in files],
+        }
+    ]
+
+
+def a_project_with(project_dir: Path, name: str, text: str) -> Path:
+    path = project_dir / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(text.encode("utf-8"))
+    return project_dir
+
+
+def write_index(project_dir: Path, entries: object) -> None:
+    path = project_dir / INDEX_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+
+def snooze(project_dir: Path, monkeypatch: pytest.MonkeyPatch, findings: list) -> None:
+    feed_stdin(monkeypatch, findings)
+    assert run(parse_args(["--snooze"]), project_dir) == 0, f"--snooze failed in {project_dir}"

--- a/tests/test_an_affirmation_covers_only_its_own_file.py
+++ b/tests/test_an_affirmation_covers_only_its_own_file.py
@@ -1,0 +1,95 @@
+"""Which snoozes a recorded content covers, and which it must not (#163).
+
+An affirmation is read back per key *and* anchor, because a key is not always
+one file (``snooze_lapse.anchor_file`` says when). Affirming the key instead
+would exempt a file nobody judged.
+
+What ``--snooze`` writes is ``test_snooze_records_the_content_it_affirmed.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from habit_hooks import snooze_lapse
+from habit_hooks.snooze import load_index
+from habit_hooks.snooze_lapse import Lapse, content_hash
+from snooze_project import a_project_with, aliased, finding, snooze, write_index
+
+
+def test_an_index_that_recorded_nothing_reads_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every hook run asks this, so it must not hash a file to learn that an
+    index written before #163 has nothing to compare. The anchor is handed in as
+    changed, so an empty answer can only come from the empty record."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    write_index(tmp_path, ["src/x.ts"])
+    monkeypatch.setattr(
+        snooze_lapse,
+        "content_hash",
+        lambda path: pytest.fail(f"hashed {path} with nothing recorded"),
+    )
+    findings = [finding("src/x.ts", "src/x.ts")]
+    asked = Lapse({"src/x.ts"}).affirming(load_index(tmp_path), findings, tmp_path)
+    assert asked.affirmed == set()
+
+
+def test_an_affirmation_covers_only_the_file_it_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The run reports one key through two files and only one was affirmed, so
+    only that one is spared."""
+    a_project_with(tmp_path, "src/a.py", "import requests\n")
+    a_project_with(tmp_path, "src/b.py", "import requests\nrequests.get()\n")
+    snooze(tmp_path, monkeypatch, aliased("src/b.py"))
+
+    findings = aliased("src/a.py", "src/b.py")
+    lapse = Lapse({"src/a.py"}).affirming(load_index(tmp_path), findings, tmp_path)
+
+    assert lapse.spares("requests", "src/b.py")
+    assert not lapse.spares("requests", "src/a.py")
+
+
+def test_a_file_git_calls_unchanged_is_spared_though_its_record_no_longer_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The git half of the AND, in the direction the digest cannot answer for.
+
+    Someone lands work on the base ref after the affirmation, so the recorded
+    content no longer matches — but this branch never touched the file, and
+    leaving such a branch alone is what the ratchet was adopted for. Only the
+    ``and`` keeps the alert off it; a content-only rule would fire here.
+    """
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    a_project_with(tmp_path, "src/x.ts", "export const a = 2;\n")
+
+    index = load_index(tmp_path)
+    assert index["src/x.ts"]["src/x.ts"] != content_hash(tmp_path / "src/x.ts")
+
+    findings = [finding("src/x.ts", "src/x.ts")]
+    assert Lapse(frozenset()).affirming(index, findings, tmp_path).spares(
+        "src/x.ts", "src/x.ts"
+    )
+    assert not Lapse({"src/x.ts"}).affirming(index, findings, tmp_path).spares(
+        "src/x.ts", "src/x.ts"
+    )
+
+
+def test_a_file_that_only_now_reports_a_key_is_not_affirmed_by_another(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The entry was recorded while one file reported the key, which is the case
+    this change is for. A second file picking the smell up later is new debt, and
+    surfacing it is what the ratchet is."""
+    a_project_with(tmp_path, "src/a.py", "import requests\n")
+    snooze(tmp_path, monkeypatch, aliased("src/a.py"))
+
+    a_project_with(tmp_path, "src/b.py", "import requests\nrequests.get()\n")
+    findings = aliased("src/a.py", "src/b.py")
+    lapse = Lapse({"src/b.py"}).affirming(load_index(tmp_path), findings, tmp_path)
+
+    assert not lapse.spares("requests", "src/b.py")

--- a/tests/test_prune_keeps_what_the_run_still_reports.py
+++ b/tests/test_prune_keeps_what_the_run_still_reports.py
@@ -1,7 +1,9 @@
 """What ``--prune`` keeps and reaps once an entry records something (#163).
 
 ``--prune`` reaps what the latest run no longer reports. An entry now carries
-recordings, and reaping the key they belong to must not reach into them.
+recordings, so it has two ways to go stale: the key itself, which #94 already
+covered, and one anchor of a key that is still live. Neither may take the other
+with it.
 """
 
 from __future__ import annotations
@@ -11,7 +13,8 @@ from pathlib import Path
 import pytest
 
 from habit_hooks.snooze import load_index, parse_args, run
-from snooze_project import a_project_with, feed_stdin, finding, snooze
+from habit_hooks.snooze_lapse import content_hash
+from snooze_project import a_project_with, aliased, feed_stdin, finding, snooze
 
 
 def test_prune_keeps_what_a_key_it_keeps_recorded(
@@ -26,3 +29,20 @@ def test_prune_keeps_what_a_key_it_keeps_recorded(
     feed_stdin(monkeypatch, [finding("src/x.ts", "src/x.ts")])
     assert run(parse_args(["--prune"]), tmp_path) == 0
     assert load_index(tmp_path) == {"src/x.ts": recorded}
+
+
+def test_prune_drops_an_anchor_the_run_no_longer_reports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An anchor goes stale inside a live entry: one file is deleted while the
+    key is still reported through another, so pruning by key alone would leave
+    the dead one recorded forever."""
+    a_project_with(tmp_path, "src/a.py", "import requests\n")
+    a_project_with(tmp_path, "src/b.py", "import requests\nrequests.get()\n")
+    snooze(tmp_path, monkeypatch, aliased("src/a.py", "src/b.py"))
+
+    feed_stdin(monkeypatch, aliased("src/b.py"))
+    assert run(parse_args(["--prune"]), tmp_path) == 0
+    assert load_index(tmp_path) == {
+        "requests": {"src/b.py": content_hash(tmp_path / "src/b.py")}
+    }

--- a/tests/test_prune_keeps_what_the_run_still_reports.py
+++ b/tests/test_prune_keeps_what_the_run_still_reports.py
@@ -1,0 +1,28 @@
+"""What ``--prune`` keeps and reaps once an entry records something (#163).
+
+``--prune`` reaps what the latest run no longer reports. An entry now carries
+recordings, and reaping the key they belong to must not reach into them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from habit_hooks.snooze import load_index, parse_args, run
+from snooze_project import a_project_with, feed_stdin, finding, snooze
+
+
+def test_prune_keeps_what_a_key_it_keeps_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rebuilding a bare list of keys would strip every affirmation on the next
+    prune."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    recorded = load_index(tmp_path)["src/x.ts"]
+
+    feed_stdin(monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert run(parse_args(["--prune"]), tmp_path) == 0
+    assert load_index(tmp_path) == {"src/x.ts": recorded}

--- a/tests/test_snooze.py
+++ b/tests/test_snooze.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import pytest
 
 from habit_hooks import sensors
-from habit_hooks.snooze import anchor_file, parse_args, transform
+from habit_hooks.snooze import parse_args, transform
+from habit_hooks.snooze_lapse import anchor_file
 
 _FINDING = {
     "smell": "oversized-file",

--- a/tests/test_snooze.py
+++ b/tests/test_snooze.py
@@ -14,7 +14,7 @@ import pytest
 
 from habit_hooks import sensors
 from habit_hooks.snooze import parse_args, transform
-from habit_hooks.snooze_lapse import anchor_file
+from habit_hooks.snooze_lapse import Lapse, anchor_file
 
 _FINDING = {
     "smell": "oversized-file",
@@ -45,18 +45,18 @@ def test_no_lapsed_file_drops_every_snoozed_issue() -> None:
 
 
 def test_a_lapsed_file_resurfaces_only_its_own_issue() -> None:
-    kept = transform([_FINDING], {"src/x.ts", "requests"}, {"src/y.py"})
+    kept = transform([_FINDING], {"src/x.ts", "requests"}, Lapse({"src/y.py"}))
     assert [issue["key"] for issue in kept[0]["issues"]] == ["requests"]
 
 
 def test_a_lapsed_file_leaves_unsnoozed_issues_alone() -> None:
-    kept = transform([_FINDING], set(), {"src/y.py"})
+    kept = transform([_FINDING], set(), Lapse({"src/y.py"}))
     assert [issue["key"] for issue in kept[0]["issues"]] == ["src/x.ts", "requests"]
 
 
 def test_a_finding_without_issues_passes_through() -> None:
     empty = {"smell": "duplicated-code", "details": {}, "issues": []}
-    assert transform([empty], {"src/x.ts"}, {"src/x.ts"}) == [empty]
+    assert transform([empty], {"src/x.ts"}, Lapse({"src/x.ts"})) == [empty]
 
 
 def test_file_run_bypasses_the_snooze_transformer(tmp_path: Path) -> None:

--- a/tests/test_snooze_index.py
+++ b/tests/test_snooze_index.py
@@ -52,7 +52,7 @@ def test_prune_drops_a_key_that_no_longer_appears(
     _write_index(tmp_path, json.dumps(["src/x.ts", "src/y.ts"]))
     _feed_stdin(monkeypatch, [_finding("src/x.ts")])
     assert run(parse_args(["--prune"]), tmp_path) == 0
-    assert load_index(tmp_path) == ["src/x.ts"]
+    assert load_index(tmp_path) == {"src/x.ts": {}}
 
 
 def test_prune_refuses_to_empty_a_populated_index_on_no_findings(
@@ -66,7 +66,7 @@ def test_prune_refuses_to_empty_a_populated_index_on_no_findings(
     _write_index(tmp_path, json.dumps(["src/x.ts", "src/y.ts"]))
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
     assert run(parse_args(["--prune"]), tmp_path) == 1
-    assert load_index(tmp_path) == ["src/x.ts", "src/y.ts"]
+    assert load_index(tmp_path) == {"src/x.ts": {}, "src/y.ts": {}}
     assert "prune" in capsys.readouterr().err.lower()
 
 
@@ -78,7 +78,7 @@ def test_prune_still_clears_an_index_it_was_asked_to_when_findings_exist(
     _write_index(tmp_path, json.dumps(["src/x.ts"]))
     _feed_stdin(monkeypatch, [_finding("src/other.ts")])
     assert run(parse_args(["--prune"]), tmp_path) == 0
-    assert load_index(tmp_path) == []
+    assert load_index(tmp_path) == {}
 
 
 @pytest.mark.parametrize(
@@ -99,6 +99,35 @@ def test_a_malformed_index_fails_by_name(
     assert str(path) in str(excinfo.value), why
 
 
+def test_an_index_of_bare_keys_still_loads(tmp_path: Path) -> None:
+    """Every entry records nothing, which is how an index a project already
+    has checked in reads: those keys keep the behaviour they have until a
+    ``--snooze`` renews them."""
+    _write_index(tmp_path, json.dumps(["src/x.ts", "src/y.ts"]))
+    assert load_index(tmp_path) == {"src/x.ts": {}, "src/y.ts": {}}
+
+
+def test_an_index_mixing_both_shapes_loads(tmp_path: Path) -> None:
+    """Which is how a project migrates: one ``--snooze`` at a time, never a flag
+    day, so a half-migrated index is the normal state for a while."""
+    recorded = {"key": "src/y.ts", "anchors": {"src/y.ts": "sha256:abc"}}
+    _write_index(tmp_path, json.dumps(["src/x.ts", recorded]))
+    assert load_index(tmp_path) == {
+        "src/x.ts": {},
+        "src/y.ts": {"src/y.ts": "sha256:abc"},
+    }
+
+
+def test_an_entry_recording_nothing_is_written_as_a_bare_key(tmp_path: Path) -> None:
+    """So a project nothing has re-affirmed into keeps the file it knows, and the
+    diff of the first affirmation shows only the entry that earned one."""
+    save_index({"src/x.ts": {}, "src/y.ts": {"src/y.ts": "sha256:abc"}}, tmp_path)
+    assert json.loads((tmp_path / INDEX_PATH).read_text(encoding="utf-8")) == [
+        "src/x.ts",
+        {"key": "src/y.ts", "anchors": {"src/y.ts": "sha256:abc"}},
+    ]
+
+
 @pytest.mark.parametrize("index_op", ["--list", "--snooze", "--prune"])
 def test_a_corrupt_index_fails_as_a_tool_error(
     index_op: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -112,7 +141,7 @@ def test_a_corrupt_index_fails_as_a_tool_error(
 
 
 def test_save_index_writes_atomically_leaving_no_temp_files(tmp_path: Path) -> None:
-    save_index(["src/x.ts"], tmp_path)
+    save_index({"src/x.ts": {}}, tmp_path)
     index_dir = tmp_path / INDEX_PATH.parent
     assert [p.name for p in index_dir.iterdir()] == ["snooze.json"]
-    assert load_index(tmp_path) == ["src/x.ts"]
+    assert load_index(tmp_path) == {"src/x.ts": {}}

--- a/tests/test_snooze_records_the_content_it_affirmed.py
+++ b/tests/test_snooze_records_the_content_it_affirmed.py
@@ -1,0 +1,168 @@
+"""What ``--snooze`` writes into an entry, and what keeps it there (#163).
+
+An entry records the content of each file it was granted against, and this is
+what that recording promises: it replaces rather than accumulates, it does not
+mistake a line ending for an edit, it survives a run that measured nothing about
+it, and it stays out of ``--list``. What ``--prune`` then keeps and reaps is
+``test_prune_keeps_what_the_run_still_reports.py``; which snoozes the record
+covers is ``test_an_affirmation_covers_only_its_own_file.py``; and the lapse
+itself is in ``docs/habit-snooze.spec.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from habit_hooks.snooze import load_index, parse_args, run
+from habit_hooks.snooze_lapse import anchor_file, content_hash, renewed
+from snooze_project import a_project_with, aliased, finding, snooze
+
+
+def test_snooze_records_the_anchor_files_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert load_index(tmp_path) == {
+        "src/x.ts": {"src/x.ts": content_hash(tmp_path / "src/x.ts")}
+    }
+
+
+def test_an_edit_changes_the_recorded_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of recording it: a later edit is a different answer."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    before = load_index(tmp_path)["src/x.ts"]
+
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\nexport const b = 2;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert load_index(tmp_path)["src/x.ts"] != before
+
+
+def test_snoozing_again_replaces_the_entry_rather_than_adding_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Appending would leave the stale content beside the fresh one, and every
+    later run would have two answers to choose between."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    a_project_with(tmp_path, "src/x.ts", "export const a = 2;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert list(load_index(tmp_path)) == ["src/x.ts"]
+
+
+def test_an_anchor_that_is_no_file_records_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sensor may key by module or export name, so the anchor is often not a
+    path at all. There is nothing to record, and the entry keeps the behaviour
+    it had before #163 rather than failing the run."""
+    snooze(tmp_path, monkeypatch, [finding("SomeExportedName")])
+    assert load_index(tmp_path) == {"SomeExportedName": {}}
+
+
+@pytest.mark.parametrize("file", [None, 5, ""], ids=["null", "a number", "empty"])
+def test_a_details_file_that_is_no_path_falls_back_to_the_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file: object
+) -> None:
+    """`sensors.finding_paths` reads a `file` that is not a non-empty string as
+    absent and lets the issue through rather than failing its sensor, so one
+    reaches here. Recording opens the anchor as a path, so reading it any other
+    way turns a tolerated finding into a traceback."""
+    issue = {"key": "k", "details": {"file": file}}
+    assert anchor_file(issue) == "k"
+
+    snooze(tmp_path, monkeypatch, [{"smell": "s", "details": {}, "issues": [issue]}])
+    assert load_index(tmp_path) == {"k": {}}
+
+
+def test_an_unreadable_anchor_keeps_what_was_recorded_before(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file briefly unreadable is not an answer. Replacing an affirmation with
+    nothing would lapse it on the next run for a reason nobody chose."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    recorded = load_index(tmp_path)["src/x.ts"]
+
+    (tmp_path / "src/x.ts").unlink()
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert load_index(tmp_path)["src/x.ts"] == recorded
+
+
+def test_the_recorded_content_ignores_a_crlf_line_ending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``snooze.json`` is checked in and shared, and git already reports nothing
+    for a CRLF-only difference under ``core.autocrlf``. Hashing raw bytes would
+    lapse a Windows developer's affirmation the moment Linux CI read it."""
+    crlf = a_project_with(tmp_path / "crlf", "x.ts", "const a = 1;\r\nconst b = 2;\r\n")
+    lf = a_project_with(tmp_path / "lf", "x.ts", "const a = 1;\nconst b = 2;\n")
+
+    snooze(crlf, monkeypatch, [finding("x.ts", "x.ts")])
+    snooze(lf, monkeypatch, [finding("x.ts", "x.ts")])
+
+    assert load_index(crlf) == load_index(lf)
+
+
+def test_a_lone_carriage_return_is_content_and_not_a_line_ending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rule forgives a line ending, not any byte resembling one. Measured: a
+    file rewritten with a lone ``\\r`` is reported as changed with ``core.autocrlf``
+    set and without it, so forgiving that too would forgive an edit every checkout
+    agrees is an edit — unlike ``\\r\\n``, where the two settings disagree."""
+    cr = a_project_with(tmp_path / "cr", "x.ts", "const a = 1;\rconst b = 2;\r")
+    lf = a_project_with(tmp_path / "lf", "x.ts", "const a = 1;\nconst b = 2;\n")
+
+    snooze(cr, monkeypatch, [finding("x.ts", "x.ts")])
+    snooze(lf, monkeypatch, [finding("x.ts", "x.ts")])
+
+    assert load_index(cr) != load_index(lf)
+
+
+def test_a_key_reported_under_several_files_records_each_of_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A key is not always one file (``snooze_lapse.anchor_file`` says when). One
+    content could only describe one of them, and which one would come down to the
+    order the sensor listed them in."""
+    a_project_with(tmp_path, "src/a.py", "import requests\n")
+    a_project_with(tmp_path, "src/b.py", "import requests\nrequests.get()\n")
+
+    snooze(tmp_path, monkeypatch, aliased("src/a.py", "src/b.py"))
+
+    assert load_index(tmp_path) == {
+        "requests": {
+            "src/a.py": content_hash(tmp_path / "src/a.py"),
+            "src/b.py": content_hash(tmp_path / "src/b.py"),
+        }
+    }
+
+
+def test_an_anchor_the_run_does_not_report_keeps_what_it_recorded(
+    tmp_path: Path,
+) -> None:
+    """A run narrowed to one file measures nothing about the others an entry
+    covers, and a snooze must not lapse because of a question nobody asked.
+    ``--prune`` is where an anchor that is really gone is dropped."""
+    a_project_with(tmp_path, "src/a.py", "import requests\n")
+    a_project_with(tmp_path, "src/b.py", "import requests\nrequests.get()\n")
+    both = renewed({}, aliased("src/a.py", "src/b.py"), tmp_path)
+
+    assert renewed(both, aliased("src/a.py"), tmp_path) == both
+
+
+def test_list_prints_bare_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--list`` shows what is snoozed, not the bookkeeping that decides for how
+    long."""
+    a_project_with(tmp_path, "src/x.ts", "export const a = 1;\n")
+    snooze(tmp_path, monkeypatch, [finding("src/x.ts", "src/x.ts")])
+    assert run(parse_args(["--list"]), tmp_path) == 0
+    assert capsys.readouterr().out == "src/x.ts\n"

--- a/tests/test_the_index_refuses_an_entry_it_cannot_mean.py
+++ b/tests/test_the_index_refuses_an_entry_it_cannot_mean.py
@@ -1,0 +1,130 @@
+"""An entry the index cannot mean is refused, never quietly flattened (#163).
+
+An entry that may be an object as well as a bare key is one more way for
+something to survive a load only to be dropped on the next write. An index read
+as something it does not say is a false clean — the #78/#84 class — so
+``_parse_index`` refuses every shape it cannot mean by name, and says what is
+allowed instead. The document-level refusals are in ``test_snooze_index.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from habit_hooks.snooze import INDEX_PATH, SnoozeError, load_index
+
+
+def _write_index(project_dir: Path, content: str) -> Path:
+    path = project_dir / INDEX_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("entry", "why"),
+    [
+        ({"key": "src/a.py", "reason": "we discussed it"}, "an unknown field"),
+        ({"anchors": {"src/a.py": "sha256:abc"}}, "no key at all"),
+        ({"key": "src/a.py", "anchors": "sha256:abc"}, "anchors that are not a table"),
+        ({"key": "src/a.py", "anchors": {"src/a.py": 5}}, "a content that is no digest"),
+        (["src/a.py"], "a nested list"),
+        (7, "a number"),
+    ],
+)
+def test_an_entry_the_index_cannot_mean_fails_by_name(
+    tmp_path: Path, entry: object, why: str
+) -> None:
+    """An entry carrying something the index has no meaning for is refused, not
+    loaded and dropped on the next write. That silent flattening is what the
+    index is parsed strictly to prevent (#94), and an entry that may be an object
+    rather than a key is one more way for it to happen."""
+    _write_index(tmp_path, json.dumps([entry]))
+    with pytest.raises(SnoozeError) as excinfo:
+        load_index(tmp_path)
+    assert "expected each entry" in str(excinfo.value), why
+
+
+@pytest.mark.parametrize(
+    ("entries", "why"),
+    [
+        (
+            ["src/a.py", {"key": "src/a.py", "anchors": {"src/a.py": "sha256:abc"}}],
+            "a bare key before a recorded one",
+        ),
+        (
+            [{"key": "src/a.py", "anchors": {"src/a.py": "sha256:abc"}}, "src/a.py"],
+            "a recorded key after a bare one",
+        ),
+        (
+            [
+                {"key": "a", "anchors": {"src/a.py": "sha256:abc"}},
+                {"key": "a", "anchors": {"src/a.py": "sha256:def"}},
+            ],
+            "two records disagreeing about one anchor",
+        ),
+    ],
+)
+def test_a_key_written_twice_with_different_anchors_fails_by_name(
+    tmp_path: Path, entries: list, why: str
+) -> None:
+    """Loading into a mapping keeps the last, so the order in the file would
+    silently decide which recording survives."""
+    _write_index(tmp_path, json.dumps(entries))
+    with pytest.raises(SnoozeError) as excinfo:
+        load_index(tmp_path)
+    assert "twice" in str(excinfo.value), why
+
+
+@pytest.mark.parametrize(
+    ("entries", "loaded"),
+    [
+        (["a", "a"], {"a": {}}),
+        (
+            [
+                {"key": "a", "anchors": {"src/a.py": "sha256:abc"}},
+                {"key": "a", "anchors": {"src/a.py": "sha256:abc"}},
+            ],
+            {"a": {"src/a.py": "sha256:abc"}},
+        ),
+    ],
+    ids=["two bare keys, which 1.5.0 already accepted", "two records that agree"],
+)
+def test_a_key_written_twice_saying_the_same_thing_loads(
+    tmp_path: Path, entries: list, loaded: dict
+) -> None:
+    """Collapsing them loses nothing, and refusing would break an index that
+    every earlier version read without complaint."""
+    _write_index(tmp_path, json.dumps(entries))
+    assert load_index(tmp_path) == loaded
+
+
+@pytest.mark.parametrize(
+    ("text", "why"),
+    [
+        ('[{"key": "a", "key": "b"}]', "a field written twice"),
+        ('[{"key": "a", "anchors": {"x": "sha256:1", "x": "sha256:2"}}]', "an anchor twice"),
+    ],
+)
+def test_a_name_written_twice_inside_one_object_fails_by_name(
+    tmp_path: Path, text: str, why: str
+) -> None:
+    """`json` keeps the last of two members sharing a name, so this would load as
+    one of them with nothing said — the same silent loss, one level further in."""
+    _write_index(tmp_path, text)
+    with pytest.raises(SnoozeError) as excinfo:
+        load_index(tmp_path)
+    assert "once" in str(excinfo.value), why
+
+
+def test_a_refusal_names_the_shape_an_entry_may_take(tmp_path: Path) -> None:
+    """A refusal has to say what is allowed, not only that this was not: a
+    message naming no shape leaves the reader to guess the format."""
+    _write_index(tmp_path, json.dumps([{"key": "src/a.py", "reason": "no"}]))
+    message = str(pytest.raises(SnoozeError, load_index, tmp_path).value)
+    assert "snoozed key" in message
+    assert '"anchors"' in message
+    assert "an object" in message


### PR DESCRIPTION
Closes #163. No new option — `--snooze` itself is fixed, as decided on the issue.

An entry was only a path, so a second `--snooze` wrote the same file again and nothing changed.
An entry now also stores the content of each file it covers:

```json
[{"key": "requests", "anchors": {"src/a.py": "sha256:…", "src/b.py": "sha256:…"}}]
```

A snooze now stops working only if **both** of these are true:

1. git says the file changed since the branch started, and
2. the file no longer matches the stored content.

So running `--snooze` again clears the finding, until the next edit.

Both conditions are needed. The spec already promises that "work someone else lands on the base
ref afterwards never lapses a snooze you did not touch", and the case `### Work landed on the base
ref afterwards lapses nothing` checks it. If we compared only content, that case would fail.

## Compatibility and details

An entry that stores nothing stays a plain string. An old index still loads, and is written back
unchanged. A project moves to the new format one `--snooze` at a time. `--list` prints plain keys
in both cases.

An entry stores one hash per **file**, not one per key, because a key can stand for several files
(`deptry` uses module names, `knip` uses export names). A hash for the key alone would cover a file
that nobody looked at.

`--prune` now also drops a file that the run no longer reports, not only a key. Its other rules are
unchanged.

Hashes ignore the difference between `\r\n` and `\n`. This is slightly more forgiving than
`git diff`, and it means a hash written on Windows still matches on Linux. I did not use
`git hash-object`, because `--snooze` has to work without a git repository.

## Two things worth knowing before merging

**1.5.0 cannot read an index that stores content.** It raises `SnoozeError` and exits 2. This is
also true for an index that is only half migrated. So the upgrade works forwards but not backwards:
if one person on a team upgrades, the runs of everyone else fail, and CI fails too, until they
upgrade as well. The failure is loud and names the file, which is the right way to fail, but it is
still a breaking change in a minor version.

It also affects people who do not use this feature. `--snooze` stores content even without
`--until-changed`. A project that uses plain `snooze` gets the same break.

**`--snooze` re-affirms everything you give it.** If you run
`habit-sensors --all | habit-snooze --snooze` to add one key, it also re-affirms every other lapsed
entry in the pipe. It even stores a file that has only just started to report a key you snoozed
earlier. Nothing is printed, and `--list` looks the same before and after. Only the index file
shows it.

This follows directly from fixing `--snooze` instead of adding a flag. It is the best remaining
argument for the `--reaffirm` flag that was rejected. The spec case states it.

Three smaller limits, all known: the index is written on one line, so a re-affirmation shows up as
one changed line; two `--snooze` runs at the same time can still lose an update, as before; and a
smudge filter such as `ident` rewrites the file on commit, so the stored hash never matches again.

## Tests

- New acceptance case in `docs/habit-snooze.spec.md`: `--snooze` re-affirms a lapsed entry, and the
  next edit brings the finding back. It fails on `main`.
- New unit tests for what an entry records, which snoozes a recording covers, what `--prune` keeps
  and reaps, and every shape the index now refuses.

`uv run pytest tests/ docs/` → 821 passed, 5 skipped, on Python 3.11, the version CI pins.
`ruff check` and `habit-hooks --all` are both clean.

## Changelog

I did not touch `CHANGELOG.md`. One sentence, if it is useful:

> **`--snooze` re-affirms a snooze whose file has changed**, clearing the finding until the next
> edit instead of writing the index back unchanged. Recording that needs a new entry shape, which
> every `--snooze` writes — plain `snooze` too — so an index this version has written cannot be
> read by 1.5.0.
